### PR TITLE
Roman dev

### DIFF
--- a/tests/Cassandra_session.py
+++ b/tests/Cassandra_session.py
@@ -26,7 +26,7 @@ class Cassandra:
         if instance == "dev":
             self.cassandra_cluster = "10.0.20.104"
         elif instance == "sandbox":
-            self.cassandra_cluster = "10.0.10.106"
+            self.cassandra_cluster = "10.0.10.104"
 
     def execute_cql_from_orchestrator_operation_step(self, task_id):
         auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)
@@ -48,10 +48,9 @@ class Cassandra:
         rows_2 = session.execute(
             f"SELECT * FROM orchestrator_operation_step WHERE process_id = '{process_id}' AND "
             f"task_id='{task_id}';").one()
-        request_data = json.loads(rows_2.request_data)
         response_data = json.loads(rows_2.response_data)
-        step_date = rows_2.step_date.strftime("%Y-%m-%dT%H:%M:%SZ")
-        context = json.loads(rows_2.context)
+        request_data = json.loads(rows_2.request_data)
+        return response_data, request_data
 
     def execute_cql_from_clarification_rules_by_country_pmd_parameter(self, country, pmd, parameter):
         auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)

--- a/tests/bpe_cancel_tender_or_lot/test_bpe_cancel_lot.py
+++ b/tests/bpe_cancel_tender_or_lot/test_bpe_cancel_lot.py
@@ -58,6 +58,20 @@ class TestCheckOnThePossibilityOfLotCancellationForTenderInActiveClarificationTe
             cp_id=create_ev_response[0],
             ev_id=create_ev_response[3]
         )
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        CancelLot.instance_tender_url = instance_tender_url
+        CancelLot.instance_budget_url = instance_budget_url
+        CancelLot.instance_storage_url = instance_storage_url
         CancelLot.payload = payload
         CancelLot.cp_id = create_ev_response[0]
         CancelLot.ev_id = create_ev_response[3]
@@ -112,7 +126,7 @@ class TestCheckOnThePossibilityOfLotCancellationForTenderInActiveClarificationTe
                 "documentType": CancelLot.payload['amendments'][0]['documents'][0]['documentType'],
                 "title": CancelLot.payload['amendments'][0]['documents'][0]['title'],
                 "description": CancelLot.payload['amendments'][0]['documents'][0]['description'],
-                "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                "url": f"{CancelLot.instance_storage_url}"
                        f"{CancelLot.payload['amendments'][0]['documents'][0]['id']}",
                 "datePublished": CancelLot.message_from_kafka['data']['operationDate']
             }]
@@ -129,7 +143,7 @@ class TestCheckOnThePossibilityOfLotCancellationForTenderInActiveClarificationTe
     @pytestrail.case('27607')
     def test_compare_ev_release_before_updating_and_after_updating_27607_4(self):
         ms_release_after_cancelling = requests.get(
-            url=f"http://dev.public.eprocurement.systems/tenders/{CancelLot.cp_id}/{CancelLot.cp_id}").json()
+            url=f"{CancelLot.instance_tender_url}{CancelLot.cp_id}/{CancelLot.cp_id}").json()
 
         expected_result = {}
         actual_result = DeepDiff(CancelLot.ms_release_before_lot_cancelling, ms_release_after_cancelling)
@@ -181,6 +195,20 @@ class TestCheckOnThePossibilityOfLotCancellationForTenderInActiveClarificationTe
             cp_id=create_ev_response[0],
             ev_id=create_ev_response[3]
         )
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        CancelLot.instance_tender_url = instance_tender_url
+        CancelLot.instance_budget_url = instance_budget_url
+        CancelLot.instance_storage_url = instance_storage_url
         CancelLot.payload = payload
         CancelLot.cp_id = create_ev_response[0]
         CancelLot.ev_id = create_ev_response[3]
@@ -243,7 +271,7 @@ class TestCheckOnThePossibilityOfLotCancellationForTenderInActiveClarificationTe
     @pytestrail.case('27608')
     def test_compare_ev_release_before_updating_and_after_updating_27608_4(self):
         ms_release_after_cancelling = requests.get(
-            url=f"http://dev.public.eprocurement.systems/tenders/{CancelLot.cp_id}/{CancelLot.cp_id}").json()
+            url=f"{CancelLot.instance_tender_url}{CancelLot.cp_id}/{CancelLot.cp_id}").json()
         expected_result = {}
         actual_result = DeepDiff(CancelLot.ms_release_before_lot_cancelling, ms_release_after_cancelling)
         assert compare_actual_result_and_expected_result(

--- a/tests/bpe_cancel_tender_or_lot/test_bpe_cancel_tender.py
+++ b/tests/bpe_cancel_tender_or_lot/test_bpe_cancel_tender.py
@@ -56,6 +56,20 @@ class TestCheckOnThePossibilityOfTenderCancellationWithFullDataModelInRequestBas
             cp_id=create_ev_response[0],
             ev_id=create_ev_response[3]
         )
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        CancelCn.instance_tender_url = instance_tender_url
+        CancelCn.instance_budget_url = instance_budget_url
+        CancelCn.instance_storage_url = instance_storage_url
         CancelCn.payload = payload
         CancelCn.cp_id = create_ev_response[0]
         CancelCn.ev_id = create_ev_response[3]
@@ -110,7 +124,7 @@ class TestCheckOnThePossibilityOfTenderCancellationWithFullDataModelInRequestBas
                 "documentType": CancelCn.payload['amendments'][0]['documents'][0]['documentType'],
                 "title": CancelCn.payload['amendments'][0]['documents'][0]['title'],
                 "description": CancelCn.payload['amendments'][0]['documents'][0]['description'],
-                "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                "url": f"{CancelCn.instance_storage_url}"
                        f"{CancelCn.payload['amendments'][0]['documents'][0]['id']}",
                 "datePublished": CancelCn.message_from_kafka['data']['operationDate']
             }]
@@ -127,7 +141,7 @@ class TestCheckOnThePossibilityOfTenderCancellationWithFullDataModelInRequestBas
     @pytestrail.case('27600')
     def test_compare_ev_release_before_updating_and_after_updating_27600_4(self):
         ms_release_after_cancelling = requests.get(
-            url=f"http://dev.public.eprocurement.systems/tenders/{CancelCn.cp_id}/{CancelCn.cp_id}").json()
+            url=f"{CancelCn.instance_tender_url}{CancelCn.cp_id}/{CancelCn.cp_id}").json()
 
         expected_result = {}
         actual_result = DeepDiff(CancelCn.ms_release_before_tender_cancelling, ms_release_after_cancelling)
@@ -178,6 +192,20 @@ class TestCheckOnThePossibilityOfTenderCancellationWithObligatoryDataModelInRequ
             cp_id=create_ev_response[0],
             ev_id=create_ev_response[3]
         )
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        CancelCn.instance_tender_url = instance_tender_url
+        CancelCn.instance_budget_url = instance_budget_url
+        CancelCn.instance_storage_url = instance_storage_url
         CancelCn.payload = payload
         CancelCn.cp_id = create_ev_response[0]
         CancelCn.ev_id = create_ev_response[3]
@@ -239,7 +267,7 @@ class TestCheckOnThePossibilityOfTenderCancellationWithObligatoryDataModelInRequ
     @pytestrail.case('27601')
     def test_compare_ev_release_before_updating_and_after_updating_27601_4(self):
         ms_release_after_cancelling = requests.get(
-            url=f"http://dev.public.eprocurement.systems/tenders/{CancelCn.cp_id}/{CancelCn.cp_id}").json()
+            url=f"{CancelCn.instance_tender_url}{CancelCn.cp_id}/{CancelCn.cp_id}").json()
         expected_result = {}
         actual_result = DeepDiff(CancelCn.ms_release_before_tender_cancelling, ms_release_after_cancelling)
         assert compare_actual_result_and_expected_result(

--- a/tests/bpe_cancel_tender_or_lot/test_bpe_tender_or_lot_amendment_cancellation.py
+++ b/tests/bpe_cancel_tender_or_lot/test_bpe_tender_or_lot_amendment_cancellation.py
@@ -52,6 +52,20 @@ class TestCheckOnThePossibilityOfTenderAmendmentCancellationForTenderInActiveCla
                 cp_id=cancel_tender_response[0],
                 ev_id=cancel_tender_response[3]
             )
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        CancelTenderAmendment.instance_tender_url = instance_tender_url
+        CancelTenderAmendment.instance_budget_url = instance_budget_url
+        CancelTenderAmendment.instance_storage_url = instance_storage_url
         CancelTenderAmendment.cp_id = cancel_tender_response[0]
         CancelTenderAmendment.ev_id = cancel_tender_response[3]
         CancelTenderAmendment.pn_id = cancel_tender_response[1]
@@ -127,7 +141,7 @@ class TestCheckOnThePossibilityOfTenderAmendmentCancellationForTenderInActiveCla
     @pytestrail.case('27605')
     def test_compare_ev_release_before_updating_and_after_updating_27605_4(self):
         ms_release_after_tender_amendment_cancellation = requests.get(
-            url=f"http://dev.public.eprocurement.systems/tenders/{CancelTenderAmendment.cp_id}/"
+            url=f"{CancelTenderAmendment.instance_tender_url}{CancelTenderAmendment.cp_id}/"
                 f"{CancelTenderAmendment.cp_id}").json()
 
         expected_result = {}
@@ -184,6 +198,20 @@ class TestCheckOnThePossibilityOfTenderAmendmentCancellationForTenderInActiveCla
                 cp_id=cancel_tender_response[0],
                 ev_id=cancel_tender_response[3]
             )
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        CancelTenderAmendment.instance_tender_url = instance_tender_url
+        CancelTenderAmendment.instance_budget_url = instance_budget_url
+        CancelTenderAmendment.instance_storage_url = instance_storage_url
         CancelTenderAmendment.cp_id = cancel_tender_response[0]
         CancelTenderAmendment.ev_id = cancel_tender_response[3]
         CancelTenderAmendment.pn_id = cancel_tender_response[1]
@@ -249,7 +277,7 @@ class TestCheckOnThePossibilityOfTenderAmendmentCancellationForTenderInActiveCla
     @pytestrail.case('27606')
     def test_compare_ev_release_before_updating_and_after_updating_27606_4(self):
         ms_release_after_tender_amendment_cancellation = requests.get(
-            url=f"http://dev.public.eprocurement.systems/tenders/{CancelTenderAmendment.cp_id}/"
+            url=f"{CancelTenderAmendment.instance_tender_url}{CancelTenderAmendment.cp_id}/"
                 f"{CancelTenderAmendment.cp_id}").json()
 
         expected_result = {}
@@ -306,6 +334,20 @@ class TestCheckOnThePossibilityOfLotAmendmentCancellationForTenderInActiveClarif
                 cp_id=cancel_lot_response[0],
                 ev_id=cancel_lot_response[3]
             )
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        CancelLotAmendment.instance_tender_url = instance_tender_url
+        CancelLotAmendment.instance_budget_url = instance_budget_url
+        CancelLotAmendment.instance_storage_url = instance_storage_url
         CancelLotAmendment.cp_id = cancel_lot_response[0]
         CancelLotAmendment.ev_id = cancel_lot_response[3]
         CancelLotAmendment.pn_id = cancel_lot_response[1]
@@ -381,7 +423,7 @@ class TestCheckOnThePossibilityOfLotAmendmentCancellationForTenderInActiveClarif
     @pytestrail.case('27609')
     def test_compare_ev_release_before_updating_and_after_updating_27609_4(self):
         ms_release_after_lot_amendment_cancellation = requests.get(
-            url=f"http://dev.public.eprocurement.systems/tenders/{CancelLotAmendment.cp_id}/"
+            url=f"{CancelLotAmendment.instance_tender_url}{CancelLotAmendment.cp_id}/"
                 f"{CancelLotAmendment.cp_id}").json()
 
         expected_result = {}
@@ -438,6 +480,20 @@ class TestCheckOnThePossibilityOfLotAmendmentCancellationForTenderInActiveClarif
                 cp_id=cancel_lot_response[0],
                 ev_id=cancel_lot_response[3]
             )
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        CancelLotAmendment.instance_tender_url = instance_tender_url
+        CancelLotAmendment.instance_budget_url = instance_budget_url
+        CancelLotAmendment.instance_storage_url = instance_storage_url
         CancelLotAmendment.cp_id = cancel_lot_response[0]
         CancelLotAmendment.ev_id = cancel_lot_response[3]
         CancelLotAmendment.pn_id = cancel_lot_response[1]
@@ -504,7 +560,7 @@ class TestCheckOnThePossibilityOfLotAmendmentCancellationForTenderInActiveClarif
     @pytestrail.case('27610')
     def test_compare_ev_release_before_updating_and_after_updating_27610_4(self):
         ms_release_after_lot_amendment_cancellation = requests.get(
-            url=f"http://dev.public.eprocurement.systems/tenders/{CancelLotAmendment.cp_id}/"
+            url=f"{CancelLotAmendment.instance_tender_url}{CancelLotAmendment.cp_id}/"
                 f"{CancelLotAmendment.cp_id}").json()
 
         expected_result = {}

--- a/tests/bpe_cancel_tender_or_lot/test_bpe_tender_or_lot_amendment_confirmation.py
+++ b/tests/bpe_cancel_tender_or_lot/test_bpe_tender_or_lot_amendment_confirmation.py
@@ -52,6 +52,20 @@ class TestCheckOnThePossibilityOfTenderAmendmentConfirmationForTenderInActiveCla
                 cp_id=cancel_tender_response[0],
                 ev_id=cancel_tender_response[3]
             )
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        ConfirmTenderAmendment.instance_tender_url = instance_tender_url
+        ConfirmTenderAmendment.instance_budget_url = instance_budget_url
+        ConfirmTenderAmendment.instance_storage_url = instance_storage_url
         ConfirmTenderAmendment.cp_id = cancel_tender_response[0]
         ConfirmTenderAmendment.ev_id = cancel_tender_response[3]
         ConfirmTenderAmendment.pn_id = cancel_tender_response[1]
@@ -144,7 +158,7 @@ class TestCheckOnThePossibilityOfTenderAmendmentConfirmationForTenderInActiveCla
     def test_compare_ev_release_before_updating_and_after_updating_27602_4(self):
         before_amendment_confirmation = ConfirmTenderAmendment.ms_release_before_tender_amendment_confirmation
         ms_release_after_tender_amendment_confirmation = requests.get(
-            url=f"http://dev.public.eprocurement.systems/tenders/{ConfirmTenderAmendment.cp_id}/"
+            url=f"{ConfirmTenderAmendment.instance_tender_url}{ConfirmTenderAmendment.cp_id}/"
                 f"{ConfirmTenderAmendment.cp_id}").json()
 
         expected_result = {
@@ -222,6 +236,20 @@ class TestCheckOnThePossibilityOfTenderAmendmentConfirmationForTenderInActiveCla
                 cp_id=cancel_tender_response[0],
                 ev_id=cancel_tender_response[3]
             )
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        ConfirmTenderAmendment.instance_tender_url = instance_tender_url
+        ConfirmTenderAmendment.instance_budget_url = instance_budget_url
+        ConfirmTenderAmendment.instance_storage_url = instance_storage_url
         ConfirmTenderAmendment.cp_id = cancel_tender_response[0]
         ConfirmTenderAmendment.ev_id = cancel_tender_response[3]
         ConfirmTenderAmendment.pn_id = cancel_tender_response[1]
@@ -314,7 +342,7 @@ class TestCheckOnThePossibilityOfTenderAmendmentConfirmationForTenderInActiveCla
     def test_compare_ev_release_before_updating_and_after_updating_27603_4(self):
         before_amendment_confirmation = ConfirmTenderAmendment.ms_release_before_tender_amendment_confirmation
         ms_release_after_tender_amendment_confirmation = requests.get(
-            url=f"http://dev.public.eprocurement.systems/tenders/{ConfirmTenderAmendment.cp_id}/"
+            url=f"{ConfirmTenderAmendment.instance_tender_url}{ConfirmTenderAmendment.cp_id}/"
                 f"{ConfirmTenderAmendment.cp_id}").json()
 
         expected_result = {
@@ -393,6 +421,20 @@ class TestCheckOnThePossibilityOfLotAmendmentConfirmationForTenderInActiveClarif
                 cp_id=cancel_lot_response[0],
                 ev_id=cancel_lot_response[3]
             )
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        ConfirmLotAmendment.instance_tender_url = instance_tender_url
+        ConfirmLotAmendment.instance_budget_url = instance_budget_url
+        ConfirmLotAmendment.instance_storage_url = instance_storage_url
         ConfirmLotAmendment.cp_id = cancel_lot_response[0]
         ConfirmLotAmendment.ev_id = cancel_lot_response[3]
         ConfirmLotAmendment.pn_id = cancel_lot_response[1]
@@ -464,7 +506,7 @@ class TestCheckOnThePossibilityOfLotAmendmentConfirmationForTenderInActiveClarif
     @pytestrail.case('27611')
     def test_compare_ev_release_before_updating_and_after_updating_27611_4(self):
         ms_release_after_lot_amendment_confirmation = requests.get(
-            url=f"http://dev.public.eprocurement.systems/tenders/{ConfirmLotAmendment.cp_id}/"
+            url=f"{ConfirmLotAmendment.instance_tender_url}{ConfirmLotAmendment.cp_id}/"
                 f"{ConfirmLotAmendment.cp_id}").json()
 
         expected_result = {}
@@ -522,6 +564,20 @@ class TestCheckOnThePossibilityOfLotAmendmentConfirmationForTenderInActiveClarif
                 cp_id=cancel_lot_response[0],
                 ev_id=cancel_lot_response[3]
             )
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        ConfirmLotAmendment.instance_tender_url = instance_tender_url
+        ConfirmLotAmendment.instance_budget_url = instance_budget_url
+        ConfirmLotAmendment.instance_storage_url = instance_storage_url
         ConfirmLotAmendment.cp_id = cancel_lot_response[0]
         ConfirmLotAmendment.ev_id = cancel_lot_response[3]
         ConfirmLotAmendment.pn_id = cancel_lot_response[1]
@@ -593,7 +649,7 @@ class TestCheckOnThePossibilityOfLotAmendmentConfirmationForTenderInActiveClarif
     @pytestrail.case('27611')
     def test_compare_ev_release_before_updating_and_after_updating_27612_4(self):
         ms_release_after_lot_amendment_confirmation = requests.get(
-            url=f"http://dev.public.eprocurement.systems/tenders/{ConfirmLotAmendment.cp_id}/"
+            url=f"{ConfirmLotAmendment.instance_tender_url}{ConfirmLotAmendment.cp_id}/"
                 f"{ConfirmLotAmendment.cp_id}").json()
 
         expected_result = {}

--- a/tests/bpe_create_cnonpn/test_bpe_create_cnonpn.py
+++ b/tests/bpe_create_cnonpn/test_bpe_create_cnonpn.py
@@ -77,13 +77,25 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnFullDataModelAndC
             payload=payload
         )
         cn.get_message_from_kafka()
-
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
         CreateCn.message_from_kafka = cn.get_message_from_kafka()
         CreateCn.successfully_create_cn = cn.check_on_that_message_is_successfully_create_cn()
         CreateCn.payload = payload
         CreateCn.cp_id = create_pn_response[4]
         CreateCn.pn_id = create_pn_response[5]
-
+        CreateCn.instance_tender_url = instance_tender_url
+        CreateCn.instance_budget_url = instance_budget_url
+        CreateCn.instance_storage_url = instance_storage_url
         assert compare_actual_result_and_expected_result(
             expected_result=str(202),
             actual_result=str(create_cn_response.status_code)
@@ -104,7 +116,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnFullDataModelAndC
                 f"{CreateCn.message_from_kafka['data']['outcomes']['ev'][0]['id']}").json()
         actual_result = ev_release
         expected_result = {
-            "uri": f"http://dev.public.eprocurement.systems/tenders/{CreateCn.message_from_kafka['data']['ocid']}/"
+            "uri": f"{CreateCn.instance_tender_url}{CreateCn.message_from_kafka['data']['ocid']}/"
                    f"{CreateCn.message_from_kafka['data']['outcomes']['ev'][0]['id']}",
             "version": "1.1",
             "extensions": [
@@ -776,7 +788,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnFullDataModelAndC
                             'documentType'],
                         "title": CreateCn.payload['tender']['documents'][0]['title'],
                         "description": CreateCn.payload['tender']['documents'][0]['description'],
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{CreateCn.instance_storage_url}"
                                f"{CreateCn.document_one_was_uploaded}",
                         "datePublished": CreateCn.message_from_kafka['data']['operationDate'],
                         "relatedLots": actual_result['releases'][0]['tender']['documents'][0]['relatedLots']
@@ -786,8 +798,8 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnFullDataModelAndC
                             'documentType'],
                         "title": CreateCn.payload['tender']['documents'][1]['title'],
                         "description": CreateCn.payload['tender']['documents'][1]['description'],
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
-                               f"{CreateCn.document_one_was_uploaded}",
+                        "url": f"{CreateCn.instance_storage_url}"
+                               f"{CreateCn.document_two_was_uploaded}",
                         "datePublished": CreateCn.message_from_kafka['data']['operationDate'],
                         "relatedLots": actual_result['releases'][0]['tender']['documents'][1]['relatedLots']
                     }, {
@@ -795,7 +807,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnFullDataModelAndC
                         "documentType": CreateCn.payload['tender']['documents'][2]['documentType'],
                         "title": CreateCn.payload['tender']['documents'][2]['title'],
                         "description": CreateCn.payload['tender']['documents'][2]['description'],
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{CreateCn.instance_storage_url}"
                                f"{CreateCn.payload['tender']['documents'][2]['id']}",
                         "datePublished": CreateCn.message_from_kafka['data']['operationDate'],
                         "relatedLots": actual_result['releases'][0]['tender']['documents'][2]['relatedLots']
@@ -821,7 +833,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnFullDataModelAndC
                                     'auctionPeriod']['startDate']
                             },
                             "electronicAuctionModalities": [{
-                                "url": f"http://auction.eprocurement.systems/auctions/"
+                                "url": f"https://eauction.eprocurement.systems/auctions/"
                                        f"{CreateCn.message_from_kafka['data']['outcomes']['ev'][0]['id']}/"
                                        f"{CreateCn.first_lot_id}",
                                 "eligibleMinimumDifference": {
@@ -840,7 +852,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnFullDataModelAndC
                                     'auctionPeriod']['startDate']
                             },
                             "electronicAuctionModalities": [{
-                                "url": f"http://auction.eprocurement.systems/auctions/"
+                                "url": f"https://eauction.eprocurement.systems/auctions/"
                                        f"{CreateCn.message_from_kafka['data']['outcomes']['ev'][0]['id']}/"
                                        f"{CreateCn.second_lot_id}",
                                 "eligibleMinimumDifference": {
@@ -863,7 +875,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnFullDataModelAndC
                     "relationship": ["parent"],
                     "scheme": "ocid",
                     "identifier": CreateCn.message_from_kafka['data']['ocid'],
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/"
+                    "uri": f"{CreateCn.instance_tender_url}"
                            f"{CreateCn.message_from_kafka['data']['ocid']}/"
                            f"{CreateCn.message_from_kafka['data']['ocid']}"
                 }, {
@@ -871,7 +883,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnFullDataModelAndC
                     "relationship": ["planning"],
                     "scheme": "ocid",
                     "identifier": CreateCn.pn_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/"
+                    "uri": f"{CreateCn.instance_tender_url}"
                            f"{CreateCn.message_from_kafka['data']['ocid']}/"
                            f"{CreateCn.pn_id}"
                 }]
@@ -1420,7 +1432,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnFullDataModelAndC
                                     CreateCn.payload['tender']['procuringEntity']['persones'][0]['businessFunctions'][
                                         0]['documents'][0]['description'],
                                 "url":
-                                    f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                                    f"{CreateCn.instance_storage_url}"
                                     f"{persone_document}",
                                 "datePublished": CreateCn.message_from_kafka['data']['operationDate']
                             }]
@@ -1454,7 +1466,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnFullDataModelAndC
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": CreateCn.message_from_kafka['data']['outcomes']['ev'][0]['id'],
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/"
+                    "uri": f"{CreateCn.instance_tender_url}"
                            f"{CreateCn.message_from_kafka['data']['ocid']}/"
                            f"{CreateCn.message_from_kafka['data']['outcomes']['ev'][0]['id']}"
                 }]
@@ -1543,12 +1555,25 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnObligatoryDataMod
             payload=payload
         )
         cn.get_message_from_kafka()
-
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
         CreateCn.message_from_kafka = cn.get_message_from_kafka()
         CreateCn.successfully_create_cn = cn.check_on_that_message_is_successfully_create_cn()
         CreateCn.payload = payload
         CreateCn.cp_id = create_pn_response[4]
         CreateCn.pn_id = create_pn_response[5]
+        CreateCn.instance_tender_url = instance_tender_url
+        CreateCn.instance_budget_url = instance_budget_url
+        CreateCn.instance_storage_url = instance_storage_url
         assert compare_actual_result_and_expected_result(
             expected_result=str(202),
             actual_result=str(create_cn_response.status_code)
@@ -1618,7 +1643,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnObligatoryDataMod
             data["data"]["tender"]["lots"][1]['placeOfPerformance']['address']['addressDetails']['locality']
         actual_result = ev_release
         expected_result = {
-            "uri": f"http://dev.public.eprocurement.systems/tenders/{CreateCn.message_from_kafka['data']['ocid']}/"
+            "uri": f"{CreateCn.instance_tender_url}{CreateCn.message_from_kafka['data']['ocid']}/"
                    f"{CreateCn.message_from_kafka['data']['outcomes']['ev'][0]['id']}",
             "version": "1.1",
             "extensions": [
@@ -2235,7 +2260,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnObligatoryDataMod
                         "documentType": CreateCn.payload['tender']['documents'][0]['documentType'],
                         "title": CreateCn.payload['tender']['documents'][0]['title'],
                         "description": CreateCn.payload['tender']['documents'][0]['description'],
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{CreateCn.instance_storage_url}"
                                f"{CreateCn.payload['tender']['documents'][0]['id']}",
                         "datePublished": CreateCn.message_from_kafka['data']['operationDate'],
                         "relatedLots": actual_result['releases'][0]['tender']['documents'][0]['relatedLots']
@@ -2244,7 +2269,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnObligatoryDataMod
                         "documentType": CreateCn.payload['tender']['documents'][1]['documentType'],
                         "title": CreateCn.payload['tender']['documents'][1]['title'],
                         "description": CreateCn.payload['tender']['documents'][1]['description'],
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{CreateCn.instance_storage_url}"
                                f"{CreateCn.payload['tender']['documents'][1]['id']}",
                         "datePublished": CreateCn.message_from_kafka['data']['operationDate'],
                         "relatedLots": actual_result['releases'][0]['tender']['documents'][1]['relatedLots']
@@ -2253,7 +2278,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnObligatoryDataMod
                         "documentType": CreateCn.payload['tender']['documents'][2]['documentType'],
                         "title": CreateCn.payload['tender']['documents'][2]['title'],
                         "description": CreateCn.payload['tender']['documents'][2]['description'],
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{CreateCn.instance_storage_url}"
                                f"{CreateCn.payload['tender']['documents'][2]['id']}",
                         "datePublished": CreateCn.message_from_kafka['data']['operationDate'],
                         "relatedLots": actual_result['releases'][0]['tender']['documents'][2]['relatedLots']
@@ -2277,7 +2302,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnObligatoryDataMod
                                     'auctionPeriod']['startDate']
                             },
                             "electronicAuctionModalities": [{
-                                "url": f"http://auction.eprocurement.systems/auctions/"
+                                "url": f"https://eauction.eprocurement.systems/auctions/"
                                        f"{CreateCn.message_from_kafka['data']['outcomes']['ev'][0]['id']}/"
                                        f"{actual_result['releases'][0]['tender']['lots'][0]['id']}",
                                 "eligibleMinimumDifference": {
@@ -2295,7 +2320,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnObligatoryDataMod
                                     'auctionPeriod']['startDate']
                             },
                             "electronicAuctionModalities": [{
-                                "url": f"http://auction.eprocurement.systems/auctions/"
+                                "url": f"https://eauction.eprocurement.systems/auctions/"
                                        f"{CreateCn.message_from_kafka['data']['outcomes']['ev'][0]['id']}/"
                                        f"{actual_result['releases'][0]['tender']['lots'][1]['id']}",
                                 "eligibleMinimumDifference": {
@@ -2318,7 +2343,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnObligatoryDataMod
                     "relationship": ["parent"],
                     "scheme": "ocid",
                     "identifier": CreateCn.message_from_kafka['data']['ocid'],
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/"
+                    "uri": f"{CreateCn.instance_tender_url}"
                            f"{CreateCn.message_from_kafka['data']['ocid']}/"
                            f"{CreateCn.message_from_kafka['data']['ocid']}"
                 }, {
@@ -2326,7 +2351,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnObligatoryDataMod
                     "relationship": ["planning"],
                     "scheme": "ocid",
                     "identifier": CreateCn.pn_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/"
+                    "uri": f"{CreateCn.instance_tender_url}"
                            f"{CreateCn.message_from_kafka['data']['ocid']}/"
                            f"{CreateCn.pn_id}"
                 }]
@@ -2738,7 +2763,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnObligatoryDataMod
                                     CreateCn.payload['tender']['procuringEntity']['persones'][0]['businessFunctions'][
                                         0]['documents'][0]['description'],
                                 "url":
-                                    f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                                    f"{CreateCn.instance_storage_url}"
                                     f"{persone_document}",
                                 "datePublished": CreateCn.message_from_kafka['data']['operationDate']
                             }]
@@ -2772,7 +2797,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnObligatoryDataMod
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": CreateCn.message_from_kafka['data']['outcomes']['ev'][0]['id'],
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/"
+                    "uri": f"{CreateCn.instance_tender_url}"
                            f"{CreateCn.message_from_kafka['data']['ocid']}/"
                            f"{CreateCn.message_from_kafka['data']['outcomes']['ev'][0]['id']}"
                 }]
@@ -2850,12 +2875,25 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnObligatoryDataMod
             payload=payload
         )
         cn.get_message_from_kafka()
-
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
         CreateCn.message_from_kafka = cn.get_message_from_kafka()
         CreateCn.successfully_create_cn = cn.check_on_that_message_is_successfully_create_cn()
         CreateCn.payload = payload
         CreateCn.cp_id = create_pn_response[4]
         CreateCn.pn_id = create_pn_response[5]
+        CreateCn.instance_tender_url = instance_tender_url
+        CreateCn.instance_budget_url = instance_budget_url
+        CreateCn.instance_storage_url = instance_storage_url
         assert compare_actual_result_and_expected_result(
             expected_result=str(202),
             actual_result=str(create_cn_response.status_code)
@@ -2904,7 +2942,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnObligatoryDataMod
 
         actual_result = ev_release
         expected_result = {
-            "uri": f"http://dev.public.eprocurement.systems/tenders/{CreateCn.message_from_kafka['data']['ocid']}/"
+            "uri": f"{CreateCn.instance_tender_url}{CreateCn.message_from_kafka['data']['ocid']}/"
                    f"{CreateCn.message_from_kafka['data']['outcomes']['ev'][0]['id']}",
             "version": "1.1",
             "extensions": [
@@ -3015,7 +3053,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnObligatoryDataMod
                         "id": CreateCn.payload['tender']['documents'][0]['id'],
                         "documentType": CreateCn.payload['tender']['documents'][0]['documentType'],
                         "title": CreateCn.payload['tender']['documents'][0]['title'],
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{CreateCn.instance_storage_url}"
                                f"{CreateCn.payload['tender']['documents'][0]['id']}",
                         "datePublished": CreateCn.message_from_kafka['data']['operationDate']
                     }],
@@ -3038,7 +3076,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnObligatoryDataMod
                     "relationship": ["parent"],
                     "scheme": "ocid",
                     "identifier": CreateCn.message_from_kafka['data']['ocid'],
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/"
+                    "uri": f"{CreateCn.instance_tender_url}"
                            f"{CreateCn.message_from_kafka['data']['ocid']}/"
                            f"{CreateCn.message_from_kafka['data']['ocid']}"
                 }, {
@@ -3046,7 +3084,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnObligatoryDataMod
                     "relationship": ["planning"],
                     "scheme": "ocid",
                     "identifier": CreateCn.pn_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/"
+                    "uri": f"{CreateCn.instance_tender_url}"
                            f"{CreateCn.message_from_kafka['data']['ocid']}/"
                            f"{CreateCn.pn_id}"
                 }]
@@ -3421,7 +3459,7 @@ class TestCheckOnCorrectnessOfPublishingEvMsPnReleasesBasedOnPnObligatoryDataMod
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": CreateCn.message_from_kafka['data']['outcomes']['ev'][0]['id'],
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/"
+                    "uri": f"{CreateCn.instance_tender_url}"
                            f"{CreateCn.message_from_kafka['data']['ocid']}/"
                            f"{CreateCn.message_from_kafka['data']['outcomes']['ev'][0]['id']}"
                 }]

--- a/tests/bpe_create_fs/test_bpe_create_fs.py
+++ b/tests/bpe_create_fs/test_bpe_create_fs.py
@@ -314,6 +314,11 @@ class TestCheckOnPossibilityOfCreatingFsWithFullDataModelTreasuryMoney(object):
                 keys_list.append(i)
         procuring_entity_scheme = payload["tender"]["procuringEntity"]["identifier"]["scheme"]
         procuring_entity_id = payload["tender"]["procuringEntity"]["identifier"]["id"]
+        instance_url = None
+        if instance == "dev":
+            instance_url = "http://dev.public.eprocurement.systems/budgets/"
+        if instance == "sandbox":
+            instance_url = "http://public.eprocurement.systems/budgets/"
         assert compare_actual_result_and_expected_result(
             expected_result="uri",
             actual_result=keys_list[0]
@@ -663,7 +668,7 @@ class TestCheckOnPossibilityOfCreatingFsWithFullDataModelTreasuryMoney(object):
         )
 
         assert compare_actual_result_and_expected_result(
-            expected_result=f"http://dev.public.eprocurement.systems/budgets/{message_from_kafka['data']['ocid']}/"
+            expected_result=f"{instance_url}{message_from_kafka['data']['ocid']}/"
                             f"{message_from_kafka['data']['outcomes']['fs'][0]['id']}",
             actual_result=fs_release["uri"]
         )
@@ -946,7 +951,7 @@ class TestCheckOnPossibilityOfCreatingFsWithFullDataModelTreasuryMoney(object):
             actual_result=fs_release["releases"][0]["relatedProcesses"][0]["identifier"]
         )
         assert compare_actual_result_and_expected_result(
-            expected_result=f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}",
+            expected_result=f"{instance_url}{cp_id}/{cp_id}",
             actual_result=fs_release["releases"][0]["relatedProcesses"][0]["uri"]
         )
 
@@ -2457,6 +2462,11 @@ class TestCheckOnPossibilityOfCreatingFsWithObligatoryDataModelTreasuryMoney(obj
                 keys_list.append(i)
         procuring_entity_scheme = payload["tender"]["procuringEntity"]["identifier"]["scheme"]
         procuring_entity_id = payload["tender"]["procuringEntity"]["identifier"]["id"]
+        instance_url = None
+        if instance == "dev":
+            instance_url = "http://dev.public.eprocurement.systems/budgets/"
+        if instance == "sandbox":
+            instance_url = "http://public.eprocurement.systems/budgets/"
         assert compare_actual_result_and_expected_result(
             expected_result="uri",
             actual_result=keys_list[0]
@@ -2730,7 +2740,7 @@ class TestCheckOnPossibilityOfCreatingFsWithObligatoryDataModelTreasuryMoney(obj
         )
 
         assert compare_actual_result_and_expected_result(
-            expected_result=f"http://dev.public.eprocurement.systems/budgets/{message_from_kafka['data']['ocid']}/"
+            expected_result=f"{instance_url}{message_from_kafka['data']['ocid']}/"
                             f"{message_from_kafka['data']['outcomes']['fs'][0]['id']}",
             actual_result=fs_release["uri"]
         )
@@ -2944,7 +2954,7 @@ class TestCheckOnPossibilityOfCreatingFsWithObligatoryDataModelTreasuryMoney(obj
             actual_result=fs_release["releases"][0]["relatedProcesses"][0]["identifier"]
         )
         assert compare_actual_result_and_expected_result(
-            expected_result=f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}",
+            expected_result=f"{instance_url}{cp_id}/{cp_id}",
             actual_result=fs_release["releases"][0]["relatedProcesses"][0]["uri"]
         )
 
@@ -3342,6 +3352,11 @@ class TestCheckOnPossibilityOfCreatingFsWithFullDataModelOwnMoney(object):
                 keys_list.append(i)
         procuring_entity_scheme = payload["tender"]["procuringEntity"]["identifier"]["scheme"]
         procuring_entity_id = payload["tender"]["procuringEntity"]["identifier"]["id"]
+        instance_url = None
+        if instance == "dev":
+            instance_url = "http://dev.public.eprocurement.systems/budgets/"
+        if instance == "sandbox":
+            instance_url = "http://public.eprocurement.systems/budgets/"
         assert compare_actual_result_and_expected_result(
             expected_result="uri",
             actual_result=keys_list[0]
@@ -3843,7 +3858,7 @@ class TestCheckOnPossibilityOfCreatingFsWithFullDataModelOwnMoney(object):
         )
 
         assert compare_actual_result_and_expected_result(
-            expected_result=f"http://dev.public.eprocurement.systems/budgets/{message_from_kafka['data']['ocid']}/"
+            expected_result=f"{instance_url}{message_from_kafka['data']['ocid']}/"
                             f"{message_from_kafka['data']['outcomes']['fs'][0]['id']}",
             actual_result=fs_release["uri"]
         )
@@ -4247,7 +4262,7 @@ class TestCheckOnPossibilityOfCreatingFsWithFullDataModelOwnMoney(object):
             actual_result=fs_release["releases"][0]["relatedProcesses"][0]["identifier"]
         )
         assert compare_actual_result_and_expected_result(
-            expected_result=f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}",
+            expected_result=f"{instance_url}{cp_id}/{cp_id}",
             actual_result=fs_release["releases"][0]["relatedProcesses"][0]["uri"]
         )
 
@@ -6625,6 +6640,11 @@ class TestCheckOnPossibilityOfCreatingFsWithObligatoryDataModelOwnMoney(object):
                 keys_list.append(i)
         procuring_entity_scheme = payload["tender"]["procuringEntity"]["identifier"]["scheme"]
         procuring_entity_id = payload["tender"]["procuringEntity"]["identifier"]["id"]
+        instance_url = None
+        if instance == "dev":
+            instance_url = "http://dev.public.eprocurement.systems/budgets/"
+        if instance == "sandbox":
+            instance_url = "http://public.eprocurement.systems/budgets/"
         assert compare_actual_result_and_expected_result(
             expected_result="uri",
             actual_result=keys_list[0]
@@ -7013,7 +7033,7 @@ class TestCheckOnPossibilityOfCreatingFsWithObligatoryDataModelOwnMoney(object):
             actual_result=keys_list[96]
         )
         assert compare_actual_result_and_expected_result(
-            expected_result=f"http://dev.public.eprocurement.systems/budgets/{message_from_kafka['data']['ocid']}/"
+            expected_result=f"{instance_url}{message_from_kafka['data']['ocid']}/"
                             f"{message_from_kafka['data']['outcomes']['fs'][0]['id']}",
             actual_result=fs_release["uri"]
         )
@@ -7314,7 +7334,7 @@ class TestCheckOnPossibilityOfCreatingFsWithObligatoryDataModelOwnMoney(object):
             actual_result=fs_release["releases"][0]["relatedProcesses"][0]["identifier"]
         )
         assert compare_actual_result_and_expected_result(
-            expected_result=f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}",
+            expected_result=f"{instance_url}{cp_id}/{cp_id}",
             actual_result=fs_release["releases"][0]["relatedProcesses"][0]["uri"]
         )
 
@@ -7386,10 +7406,10 @@ class TestCheckTheCorrectSettingOfTheReleaseDateValueInTheFsRelease(object):
             cassandra_username=cassandra_username,
             cassandra_password=cassandra_password
         )
-        start_date = database.execute_cql_from_orchestrator_operation_step_by_oper_id(
+        start_date = (database.execute_cql_from_orchestrator_operation_step_by_oper_id(
             operation_id=message_from_kafka["X-OPERATION-ID"],
             task_id="NoticeCreateReleaseTask",
-        )[3]["startDate"]
+        ))[1]['context']['startDate']
         print(start_date)
 
     @pytestrail.case('27552')
@@ -7424,7 +7444,7 @@ class TestCheckTheCorrectSettingOfTheReleaseDateValueInTheFsRelease(object):
         start_date = database.execute_cql_from_orchestrator_operation_step_by_oper_id(
             operation_id=message_from_kafka["X-OPERATION-ID"],
             task_id="NoticeCreateReleaseTask",
-        )[3]["startDate"]
+        )[1]['context']['startDate']
         assert compare_actual_result_and_expected_result(
             expected_result=start_date,
             actual_result=fs_release["releases"][0]["date"]

--- a/tests/bpe_enquiry_period_end/test_bpe_enquiry_period_end.py
+++ b/tests/bpe_enquiry_period_end/test_bpe_enquiry_period_end.py
@@ -1,5 +1,6 @@
 import copy
 import datetime
+import json
 from uuid import uuid4
 import requests
 from deepdiff import DeepDiff
@@ -110,7 +111,20 @@ class TestCheckOnThePossibilityOfEnquiryPeriodReschedulingForTenderInActiveClari
             payload=payload
         )
         UpdateCn.message_from_kafka = UpdateCn.cn_class.get_message_from_kafka()
-
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        UpdateCn.instance_tender_url = instance_tender_url
+        UpdateCn.instance_budget_url = instance_budget_url
+        UpdateCn.instance_storage_url = instance_storage_url
         UpdateCn.payload = payload
         UpdateCn.cp_id = create_ev_response[0]
         UpdateCn.ev_id = create_ev_response[3]
@@ -420,7 +434,20 @@ class TestCheckOnTheImpossibilityOfEnquiryPeriodReschedulingForTenderInActiveCla
             payload=payload
         )
         UpdateCn.message_from_kafka = UpdateCn.cn_class.get_message_from_kafka()
-
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        UpdateCn.instance_tender_url = instance_tender_url
+        UpdateCn.instance_budget_url = instance_budget_url
+        UpdateCn.instance_storage_url = instance_storage_url
         UpdateCn.payload = payload
         UpdateCn.cp_id = create_ev_response[0]
         UpdateCn.ev_id = create_ev_response[3]
@@ -548,7 +575,20 @@ class TestCheckOnThePossibilityOfEnquiryPeriodReschedulingForTenderInActiveClari
             payload=payload
         )
         UpdateCn.message_from_kafka = UpdateCn.cn_class.get_message_from_kafka()
-
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        UpdateCn.instance_tender_url = instance_tender_url
+        UpdateCn.instance_budget_url = instance_budget_url
+        UpdateCn.instance_storage_url = instance_storage_url
         UpdateCn.payload = payload
         UpdateCn.cp_id = create_ev_response[0]
         UpdateCn.ev_id = create_ev_response[3]
@@ -650,8 +690,8 @@ class TestCheckOnThePossibilityOfSuspendingTender(object):
             second_lot_id=second_lot_id,
             first_item_id=first_item_id,
             second_item_id=second_item_id,
-            second_enquiry=121,
-            second_tender=302
+            second_enquiry=300,
+            second_tender=602
         )
         EnquiryGlobal.ms_release_before_enquiry_creating = requests.get(url=create_ev_response[5]).json()
         EnquiryGlobal.pn_release_before_enquiry_creating = requests.get(url=create_ev_response[6]).json()
@@ -668,6 +708,20 @@ class TestCheckOnThePossibilityOfSuspendingTender(object):
             payload=payload
         )
         EnquiryGlobal.message_from_kafka = EnquiryGlobal.enquiry_class.get_message_from_kafka()
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        EnquiryGlobal.instance_tender_url = instance_tender_url
+        EnquiryGlobal.instance_budget_url = instance_budget_url
+        EnquiryGlobal.instance_storage_url = instance_storage_url
         EnquiryGlobal.payload = payload
         EnquiryGlobal.cp_id = create_ev_response[0]
         EnquiryGlobal.ev_id = create_ev_response[3]
@@ -746,7 +800,7 @@ class TestCheckOnThePossibilityOfSuspendingTender(object):
         date_transformation = datetime.datetime.strptime(EnquiryGlobal.enquiry_period_end_date, "%Y-%m-%dT%H:%M:%SZ")
         time_bot(expected_time=date_transformation)
         ms_release_after_enquiry = requests.get(
-            url=f"http://dev.public.eprocurement.systems/tenders"
+            url=f"{EnquiryGlobal.instance_tender_url}"
                 f"/{EnquiryGlobal.cp_id}/{EnquiryGlobal.cp_id}").json()
         expected_result = {
             'values_changed': {

--- a/tests/bpe_update_cnonpn/test_bpe_update_cnonpn.py
+++ b/tests/bpe_update_cnonpn/test_bpe_update_cnonpn.py
@@ -87,6 +87,17 @@ class TestCheckOnThePossibilityOfCnOnPnUpdatingWithFullDataModel(object):
             payload=payload
         )
         UpdateCn.message_from_kafka = cn.get_message_from_kafka()
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
         UpdateCn.successfully_update_cn = cn.check_on_that_message_is_successfully_update_cn(
             cp_id=create_ev_response[0],
             ev_id=create_ev_response[3]
@@ -95,6 +106,9 @@ class TestCheckOnThePossibilityOfCnOnPnUpdatingWithFullDataModel(object):
         UpdateCn.cp_id = create_ev_response[0]
         UpdateCn.ev_id = create_ev_response[3]
         UpdateCn.pn_id = create_ev_response[1]
+        UpdateCn.instance_tender_url = instance_tender_url
+        UpdateCn.instance_budget_url = instance_budget_url
+        UpdateCn.instance_storage_url = instance_storage_url
         assert compare_actual_result_and_expected_result(
             expected_result=str(202),
             actual_result=str(update_cn_response.status_code)
@@ -111,7 +125,6 @@ class TestCheckOnThePossibilityOfCnOnPnUpdatingWithFullDataModel(object):
     def test_compare_ev_release_before_updating_and_after_updating_27598_3(self):
         ev_release_after_updating = requests.get(
             url=f"{UpdateCn.message_from_kafka['data']['url']}").json()
-
         expected_result = {
             'dictionary_item_added': "['releases'][0]['tender']['amendments']",
             'values_changed': {
@@ -359,11 +372,6 @@ class TestCheckOnThePossibilityOfCnOnPnUpdatingWithFullDataModel(object):
                     'old_value': UpdateCn.ev_release_before_cn_updating['releases'][0]['tender']['tenderPeriod'][
                         'endDate']
                 },
-                "root['releases'][0]['tender']['enquiryPeriod']['startDate']": {
-                    'new_value': ev_release_after_updating['releases'][0]['tender']['enquiryPeriod']['startDate'],
-                    'old_value': UpdateCn.ev_release_before_cn_updating['releases'][0]['tender']['enquiryPeriod'][
-                        'startDate']
-                },
                 "root['releases'][0]['tender']['enquiryPeriod']['endDate']": {
                     'new_value': ev_release_after_updating['releases'][0]['tender']['enquiryPeriod']['endDate'],
                     'old_value': UpdateCn.ev_release_before_cn_updating['releases'][0]['tender']['enquiryPeriod'][
@@ -509,10 +517,6 @@ class TestCheckOnThePossibilityOfCnOnPnUpdatingWithFullDataModel(object):
         actual_result = DeepDiff(UpdateCn.ev_release_before_cn_updating, ev_release_after_updating)
         dictionary_item_added_was_cleaned = str(actual_result['dictionary_item_added']).replace('root', '')[1:-1]
         actual_result['dictionary_item_added'] = dictionary_item_added_was_cleaned
-        assert compare_actual_result_and_expected_result(
-            expected_result=str(expected_result),
-            actual_result=str(actual_result)
-        )
         actual_amendments = ev_release_after_updating['releases'][0]['tender']['amendments']
         expected_amendments = [{
             "id": actual_amendments[0]['id'],
@@ -523,6 +527,10 @@ class TestCheckOnThePossibilityOfCnOnPnUpdatingWithFullDataModel(object):
             "rationale": "General change of Contract Notice"
         }]
         assert compare_actual_result_and_expected_result(
+            expected_result=str(expected_result),
+            actual_result=str(actual_result)
+        )
+        assert compare_actual_result_and_expected_result(
             expected_result=str(expected_amendments),
             actual_result=str(actual_amendments)
         )
@@ -530,7 +538,7 @@ class TestCheckOnThePossibilityOfCnOnPnUpdatingWithFullDataModel(object):
     @pytestrail.case('27598')
     def test_compare_ms_release_before_updating_and_after_updating_27598_4(self):
         ms_release_after_updating = requests.get(
-            url=f"http://dev.public.eprocurement.systems/tenders/{UpdateCn.cp_id}/{UpdateCn.cp_id}").json()
+            url=f"{UpdateCn.instance_tender_url}{UpdateCn.cp_id}/{UpdateCn.cp_id}").json()
 
         expected_result = {
             'values_changed': {
@@ -773,7 +781,7 @@ class TestCheckOnThePossibilityOfCnOnPnUpdatingWithFullDataModel(object):
     @pytestrail.case('27598')
     def test_compare_pn_release_before_updating_and_after_updating_27598_5(self):
         pn_release_after_updating = requests.get(
-            url=f"http://dev.public.eprocurement.systems/tenders/{UpdateCn.cp_id}/{UpdateCn.pn_id}").json()
+            url=f"{UpdateCn.instance_tender_url}{UpdateCn.cp_id}/{UpdateCn.pn_id}").json()
 
         expected_result = {}
         actual_result = DeepDiff(UpdateCn.pn_release_before_cn_updating, pn_release_after_updating)
@@ -832,6 +840,17 @@ class TestCheckOnThePossibilityOfCnOnPnUpdatingWithObligatoryDataModel(object):
             payload=payload
         )
         UpdateCn.message_from_kafka = cn.get_message_from_kafka()
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
         UpdateCn.successfully_update_cn = cn.check_on_that_message_is_successfully_update_cn(
             cp_id=create_ev_response[0],
             ev_id=create_ev_response[3]
@@ -840,6 +859,9 @@ class TestCheckOnThePossibilityOfCnOnPnUpdatingWithObligatoryDataModel(object):
         UpdateCn.cp_id = create_ev_response[0]
         UpdateCn.ev_id = create_ev_response[3]
         UpdateCn.pn_id = create_ev_response[1]
+        UpdateCn.instance_tender_url = instance_tender_url
+        UpdateCn.instance_budget_url = instance_budget_url
+        UpdateCn.instance_storage_url = instance_storage_url
         assert compare_actual_result_and_expected_result(
             expected_result=str(202),
             actual_result=str(update_cn_response.status_code)
@@ -1072,11 +1094,6 @@ class TestCheckOnThePossibilityOfCnOnPnUpdatingWithObligatoryDataModel(object):
                     'old_value': UpdateCn.ev_release_before_cn_updating['releases'][0]['tender']['tenderPeriod'][
                         'endDate']
                 },
-                "root['releases'][0]['tender']['enquiryPeriod']['startDate']": {
-                    'new_value': ev_release_after_updating['releases'][0]['tender']['enquiryPeriod']['startDate'],
-                    'old_value': UpdateCn.ev_release_before_cn_updating['releases'][0]['tender']['enquiryPeriod'][
-                        'startDate']
-                },
                 "root['releases'][0]['tender']['enquiryPeriod']['endDate']": {
                     'new_value': ev_release_after_updating['releases'][0]['tender']['enquiryPeriod']['endDate'],
                     'old_value': UpdateCn.ev_release_before_cn_updating['releases'][0]['tender']['enquiryPeriod'][
@@ -1125,7 +1142,7 @@ class TestCheckOnThePossibilityOfCnOnPnUpdatingWithObligatoryDataModel(object):
     @pytestrail.case('27599')
     def test_compare_ms_release_before_updating_and_after_updating_27599_4(self):
         ms_release_after_updating = requests.get(
-            url=f"http://dev.public.eprocurement.systems/tenders/{UpdateCn.cp_id}/{UpdateCn.cp_id}").json()
+            url=f"{UpdateCn.instance_tender_url}{UpdateCn.cp_id}/{UpdateCn.cp_id}").json()
 
         expected_result = {
             'values_changed': {
@@ -1168,7 +1185,7 @@ class TestCheckOnThePossibilityOfCnOnPnUpdatingWithObligatoryDataModel(object):
     @pytestrail.case('27599')
     def test_compare_pn_release_before_updating_and_after_updating_27599_5(self):
         pn_release_after_updating = requests.get(
-            url=f"http://dev.public.eprocurement.systems/tenders/{UpdateCn.cp_id}/{UpdateCn.pn_id}").json()
+            url=f"{UpdateCn.instance_tender_url}{UpdateCn.cp_id}/{UpdateCn.pn_id}").json()
 
         expected_result = {}
         actual_result = DeepDiff(UpdateCn.pn_release_before_cn_updating, pn_release_after_updating)

--- a/tests/bpe_update_ei/test_bpe_update_ei.py
+++ b/tests/bpe_update_ei/test_bpe_update_ei.py
@@ -20,8 +20,9 @@ class TestCheckOnPossibilityUpdateEiWithObligatoryFieldsInPayloadWithoutTenderIt
                 cassandra_username=cassandra_username, cassandra_password=cassandra_password)
         ei.insert_ei_full_data_model(cp_id=cp_id, ei_token=ei_token)
         update_ei_response = ei.update_ei(cp_id=cp_id, ei_token=ei_token)
-        actual_result = str(update_ei_response.status_code)
+        actual_result = str(update_ei_response[0].status_code)
         expected_result = str(202)
+        print(actual_result)
         assert compare_actual_result_and_expected_result(expected_result=expected_result, actual_result=actual_result)
 
     @pytestrail.case("23890")
@@ -52,7 +53,7 @@ class TestCheckOnPossibilityUpdateEiWithObligatoryFieldsInPayloadWithTenderItems
                 cassandra_username=cassandra_username, cassandra_password=cassandra_password)
         ei.insert_ei_full_data_model(cp_id=cp_id, ei_token=ei_token)
         update_ei_response = ei.update_ei(cp_id=cp_id, ei_token=ei_token)
-        actual_result = str(update_ei_response.status_code)
+        actual_result = str(update_ei_response[0].status_code)
         expected_result = str(202)
         assert compare_actual_result_and_expected_result(expected_result=expected_result,
                                                          actual_result=actual_result)
@@ -85,7 +86,7 @@ class TestCheckOnPossibilityUpdateEiWithFullDataInPayload(object):
                 cassandra_username=cassandra_username, cassandra_password=cassandra_password)
         ei.insert_ei_obligatory_data_model(cp_id=cp_id, ei_token=ei_token)
         update_ei_response = ei.update_ei(cp_id=cp_id, ei_token=ei_token)
-        actual_result = str(update_ei_response.status_code)
+        actual_result = str(update_ei_response[0].status_code)
         expected_result = str(202)
         assert compare_actual_result_and_expected_result(expected_result=expected_result,
                                                          actual_result=actual_result)
@@ -120,7 +121,7 @@ class TestCheckOnImpossibilityUpdateEiIfTokenFromRequestNotEqualTokenFromDB(obje
         ei.insert_ei_full_data_model(cp_id=cp_id, ei_token=ei_token)
         update_ei_response = ei.update_ei(cp_id=cp_id, ei_token=str(uuid4()))
         expected_result = str(202)
-        actual_result = str(update_ei_response.status_code)
+        actual_result = str(update_ei_response[0].status_code)
         assert compare_actual_result_and_expected_result(expected_result=expected_result,
                                                          actual_result=actual_result)
 
@@ -168,7 +169,7 @@ class TestCheckOnImpossibilityUpdateEiIfOwnerFromRequestNotEqualOwnerFromDB(obje
             ei_token=ei_token
         )
         expected_result = str(202)
-        actual_result = str(update_ei_response.status_code)
+        actual_result = str(update_ei_response[0].status_code)
         assert compare_actual_result_and_expected_result(expected_result=expected_result,
                                                          actual_result=actual_result)
 
@@ -191,7 +192,7 @@ class TestCheckOnImpossibilityUpdateEiIfOwnerFromRequestNotEqualOwnerFromDB(obje
             cp_id=cp_id,
             ei_token=ei_token
         )
-        ei.update_ei(
+        update_ei_response = ei.update_ei(
             cp_id=cp_id,
             ei_token=ei_token
         )
@@ -201,14 +202,13 @@ class TestCheckOnImpossibilityUpdateEiIfOwnerFromRequestNotEqualOwnerFromDB(obje
             cassandra_username=cassandra_username,
             cassandra_password=cassandra_password
         )
-
-        ei_budget_update_ei_task = database.execute_cql_from_orchestrator_operation_step(
+        ei_budget_update_ei_task = (database.execute_cql_from_orchestrator_operation_step_by_oper_id(
+            operation_id=update_ei_response[1],
             task_id='BudgetUpdateEiTask'
-        )
-        print(ei_budget_update_ei_task)
+        ))[0]
         assert compare_actual_result_and_expected_result(
-            expected_result=str([{'code': '400.10.00.03', 'description': 'Invalid owner.'}]),
-            actual_result=str(ei_budget_update_ei_task["errors"])
+            expected_result=str({"errors": [{"code": "400.10.00.03", "description": "Invalid owner."}]}),
+            actual_result=str(ei_budget_update_ei_task)
         )
 
 
@@ -304,7 +304,7 @@ class TestCheckOnImpossibilityUpdateEiIfTenderClassificationIdNotEqualTenderItem
                 cassandra_password=cassandra_password)
         ei.insert_ei_obligatory_data_model(cp_id=cp_id, ei_token=ei_token)
         update_ei_response = ei.update_ei(cp_id=cp_id, ei_token=ei_token)
-        actual_result = str(update_ei_response.status_code)
+        actual_result = str(update_ei_response[0].status_code)
         expected_result = str(202)
         assert compare_actual_result_and_expected_result(expected_result=expected_result,
                                                          actual_result=actual_result)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,9 @@ class CreatePn:
     payload = None
     ei_id = None
     fs_id = None
+    instance_tender_url = None
+    instance_budget_url = None
+    instance_storage_url = None
 
 
 class CreateCn:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,6 +116,9 @@ class CreateCn:
     second_lot_id = None
     first_item_id = None
     second_item_id = None
+    instance_tender_url = None
+    instance_budget_url = None
+    instance_storage_url = None
 
 
 class UpdateCn:
@@ -131,6 +134,9 @@ class UpdateCn:
     pn_id = None
     enquiry_period_start_date = None
     enquiry_period_end_date = None
+    instance_tender_url = None
+    instance_budget_url = None
+    instance_storage_url = None
 
 
 class EnquiryGlobal:
@@ -147,6 +153,9 @@ class EnquiryGlobal:
     enquiry_period_end_date = None
     tender_period_start_date = None
     tender_period_end_date = None
+    instance_tender_url = None
+    instance_budget_url = None
+    instance_storage_url = None
 
 
 class CancelCn:
@@ -159,6 +168,9 @@ class CancelCn:
     cp_id = None
     ev_id = None
     pn_id = None
+    instance_tender_url = None
+    instance_budget_url = None
+    instance_storage_url = None
 
 
 class CancelLot:
@@ -172,6 +184,9 @@ class CancelLot:
     ev_id = None
     pn_id = None
     lot_id = None
+    instance_tender_url = None
+    instance_budget_url = None
+    instance_storage_url = None
 
 
 class ConfirmTenderAmendment:
@@ -186,6 +201,9 @@ class ConfirmTenderAmendment:
     pn_id = None
     amendment_id = None
     amendment_token = None
+    instance_tender_url = None
+    instance_budget_url = None
+    instance_storage_url = None
 
 
 class ConfirmLotAmendment:
@@ -200,6 +218,9 @@ class ConfirmLotAmendment:
     pn_id = None
     amendment_id = None
     amendment_token = None
+    instance_tender_url = None
+    instance_budget_url = None
+    instance_storage_url = None
 
 
 class CancelTenderAmendment:
@@ -214,6 +235,9 @@ class CancelTenderAmendment:
     pn_id = None
     amendment_id = None
     amendment_token = None
+    instance_tender_url = None
+    instance_budget_url = None
+    instance_storage_url = None
 
 
 class CancelLotAmendment:
@@ -229,3 +253,6 @@ class CancelLotAmendment:
     lot_id = None
     amendment_id = None
     amendment_token = None
+    instance_tender_url = None
+    instance_budget_url = None
+    instance_storage_url = None

--- a/tests/essences/cancel_tender.py
+++ b/tests/essences/cancel_tender.py
@@ -425,6 +425,17 @@ class CancelTender:
 
         procurement_method_details_from_mdm = data_pn["data"]["tender"]["procurementMethodDetails"]
         eligibility_criteria_from_mdm = data_pn["data"]["tender"]["eligibilityCriteria"]
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if self.instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if self.instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
         json_orchestrator_context = {
             "cpid": cp_id,
             "ocid": ev_id,
@@ -1148,7 +1159,7 @@ class CancelTender:
                     "startDate": auction_date
                 },
                 "modalities": [{
-                    "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
+                    "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
                     "eligibleMinimumDifference": {
                         "amount": 100.00,
                         "currency": "EUR"
@@ -1161,7 +1172,7 @@ class CancelTender:
                     "startDate": auction_date
                 },
                 "modalities": [{
-                    "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
+                    "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
                     "eligibleMinimumDifference": {
                         "amount": 10.00,
                         "currency": "EUR"
@@ -1513,7 +1524,7 @@ class CancelTender:
                             "title": "create CNonPN: procuringEntity.persones[0].businessFunctions[0].title",
                             "description": "create CNonPN: procuringEntity.persones[0].businessFunctions[0]."
                                            "description",
-                            "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                            "url": f"{instance_storage_url}"
                                    f"{self.document_three_was_uploaded}",
                             "datePublished": operation_date
                         }]
@@ -1526,26 +1537,26 @@ class CancelTender:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/o{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/o{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "164cf530-ceca-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
         }
@@ -1749,7 +1760,7 @@ class CancelTender:
                         "documentType": "contractArrangements",
                         "title": "create Pn: tender.documents[0].title",
                         "description": "create Pn: tender.documents[0].description",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_one_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [first_lot_id]
@@ -1759,7 +1770,7 @@ class CancelTender:
                         "documentType": "contractArrangements",
                         "title": "create Pn: tender.documents[1].title",
                         "description": "create Pn: tender.documents[1].description",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_two_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [second_lot_id]
@@ -1788,7 +1799,7 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
         json_notice_release_ev = {
@@ -2274,7 +2285,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[0].title",
                     "description": "create Pn: tender.documents[0].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_one_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_one_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
                 }, {
@@ -2282,7 +2293,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[1].title",
                     "description": "create Pn: tender.documents[1].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_two_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_two_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [second_lot_id]
                 }, {
@@ -2290,7 +2301,7 @@ class CancelTender:
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
                     "description": "create CNonPN: tender.documents[2].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
@@ -2310,7 +2321,7 @@ class CancelTender:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 100.00,
                                 "currency": "EUR"
@@ -2323,7 +2334,7 @@ class CancelTender:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 10.00,
                                 "currency": "EUR"
@@ -2342,13 +2353,13 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "164cf531-ceca-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
 
@@ -2844,7 +2855,7 @@ class CancelTender:
                         "id": self.document_five_was_uploaded,
                         "title": "cancel_tender: amendments[0].documents[0].title",
                         "description": "cancel_tender: amendments[0].documents[0].description",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_five_was_uploaded}",
                         "datePublished": period[0]
                     }]
@@ -2854,7 +2865,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[0].title",
                     "description": "create Pn: tender.documents[0].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_one_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_one_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
                 }, {
@@ -2862,7 +2873,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[1].title",
                     "description": "create Pn: tender.documents[1].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_two_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [second_lot_id]
@@ -2871,7 +2882,7 @@ class CancelTender:
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
                     "description": "create CNonPN: tender.documents[2].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
@@ -2891,7 +2902,7 @@ class CancelTender:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 100.00,
                                 "currency": "EUR"
@@ -2904,7 +2915,7 @@ class CancelTender:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 10.00,
                                 "currency": "EUR"
@@ -2923,13 +2934,13 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "164cf531-ceca-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
 
@@ -3253,7 +3264,7 @@ class CancelTender:
                             "title": "create CNonPN: procuringEntity.persones[0].businessFunctions[0].title",
                             "description": "create CNonPN: procuringEntity.persones[0].businessFunctions[0]."
                                            "description",
-                            "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                            "url": f"{instance_storage_url}"
                                    f"{self.document_three_was_uploaded}",
                             "datePublished": operation_date
                         }]
@@ -3266,26 +3277,26 @@ class CancelTender:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "ed0f7290-cee4-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
 
@@ -3490,7 +3501,7 @@ class CancelTender:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_one_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [first_lot_id]
@@ -3500,7 +3511,7 @@ class CancelTender:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_two_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [second_lot_id]
@@ -3529,7 +3540,7 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}/{cp_id}/{cp_id}"
             }]
         }
         json_notice_compiled_release_ev = {
@@ -4024,7 +4035,7 @@ class CancelTender:
                         "id": self.document_five_was_uploaded,
                         "title": "cancel_tender: amendments[0].documents[0].title",
                         "description": "cancel_tender: amendments[0].documents[0].description",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_five_was_uploaded}",
                         "datePublished": period[0]
                     }]
@@ -4034,7 +4045,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[0].title",
                     "description": "create Pn: tender.documents[0].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_one_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_one_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
                 }, {
@@ -4042,7 +4053,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[1].title",
                     "description": "create Pn: tender.documents[1].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_two_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [second_lot_id]
@@ -4051,7 +4062,7 @@ class CancelTender:
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
                     "description": "create CNonPN: tender.documents[2].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
@@ -4071,7 +4082,7 @@ class CancelTender:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 100.00,
                                 "currency": "EUR"
@@ -4084,7 +4095,7 @@ class CancelTender:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 10.00,
                                 "currency": "EUR"
@@ -4103,13 +4114,13 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "ed0f7291-cee4-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
 
@@ -4183,10 +4194,10 @@ class CancelTender:
             f"release_id, stage, status) VALUES ('{cp_id}', '{ev_id}', '{json.dumps(json_notice_compiled_release_ev)}',"
             f"{period[2]},{period_for_amendment[1]}, '{ev_id + '-' + str(period_for_amendment[1])}','EV', "
             f"'active');").one()
-        record = f"http://dev.public.eprocurement.systems/tenders/{cp_id}"
-        ms_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
-        pn_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
-        ev_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+        record = f"{instance_tender_url}{cp_id}"
+        ms_release = f"{instance_tender_url}{cp_id}/{cp_id}"
+        pn_release = f"{instance_tender_url}{cp_id}/{pn_id}"
+        ev_release = f"{instance_tender_url}{cp_id}/{ev_id}"
         return cp_id, pn_id, pn_token, ev_id, record, ms_release, pn_release, ev_release, self.amendment_id, \
                self.amendment_token
 
@@ -4258,6 +4269,17 @@ class CancelTender:
 
         procurement_method_details_from_mdm = data_pn["data"]["tender"]["procurementMethodDetails"]
         eligibility_criteria_from_mdm = data_pn["data"]["tender"]["eligibilityCriteria"]
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if self.instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if self.instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
         json_orchestrator_context = {
             "cpid": cp_id,
             "ocid": ev_id,
@@ -4800,26 +4822,26 @@ class CancelTender:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/o{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/o{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "164cf530-ceca-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
         }
@@ -4867,7 +4889,7 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
         json_notice_release_ev = {
@@ -5047,7 +5069,7 @@ class CancelTender:
                     "id": self.document_three_was_uploaded,
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date
                 }],
@@ -5067,13 +5089,13 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "164cf531-ceca-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
         json_notice_release_ev_new = {
@@ -5264,7 +5286,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[0].title",
                     "description": "create Pn: tender.documents[0].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_one_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_one_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
                 }],
@@ -5284,13 +5306,13 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "164cf531-ceca-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
         json_notice_compiled_release_ms = {
@@ -5506,26 +5528,26 @@ class CancelTender:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "ed0f7290-cee4-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
 
@@ -5573,7 +5595,7 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
         json_notice_compiled_release_ev = {
@@ -5762,7 +5784,7 @@ class CancelTender:
                     "id": self.document_one_was_uploaded,
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[0].title",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_one_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_one_was_uploaded}",
                     "datePublished": operation_date
                 }],
                 "awardCriteria": "ratedCriteria",
@@ -5781,13 +5803,13 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "ed0f7291-cee4-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
 
@@ -5857,10 +5879,10 @@ class CancelTender:
             f"release_id, stage, status) VALUES ('{cp_id}', '{ev_id}', '{json.dumps(json_notice_compiled_release_ev)}',"
             f"{period[2]},{period_for_amendment[1]}, '{ev_id + '-' + str(period_for_amendment[1])}','EV', "
             f"'active');").one()
-        record = f"http://dev.public.eprocurement.systems/tenders/{cp_id}"
-        ms_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
-        pn_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
-        ev_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+        record = f"{instance_tender_url}{cp_id}"
+        ms_release = f"{instance_tender_url}{cp_id}/{cp_id}"
+        pn_release = f"{instance_tender_url}{cp_id}/{pn_id}"
+        ev_release = f"{instance_tender_url}{cp_id}/{ev_id}"
         return cp_id, pn_id, pn_token, ev_id, record, ms_release, pn_release, ev_release, self.amendment_id, \
                self.amendment_token
 
@@ -5932,6 +5954,17 @@ class CancelTender:
 
         procurement_method_details_from_mdm = data_pn["data"]["tender"]["procurementMethodDetails"]
         eligibility_criteria_from_mdm = data_pn["data"]["tender"]["eligibilityCriteria"]
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if self.instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if self.instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid1()}",
@@ -6657,7 +6690,7 @@ class CancelTender:
                     "startDate": auction_date
                 },
                 "modalities": [{
-                    "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
+                    "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
                     "eligibleMinimumDifference": {
                         "amount": 100.00,
                         "currency": "EUR"
@@ -6670,7 +6703,7 @@ class CancelTender:
                     "startDate": auction_date
                 },
                 "modalities": [{
-                    "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
+                    "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
                     "eligibleMinimumDifference": {
                         "amount": 10.00,
                         "currency": "EUR"
@@ -7004,7 +7037,7 @@ class CancelTender:
                             "title": "create CNonPN: procuringEntity.persones[0].businessFunctions[0].title",
                             "description": "create CNonPN: procuringEntity.persones[0].businessFunctions[0]."
                                            "description",
-                            "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                            "url": f"{instance_storage_url}"
                                    f"{self.document_three_was_uploaded}",
                             "datePublished": operation_date
                         }]
@@ -7017,26 +7050,26 @@ class CancelTender:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/o{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/o{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "164cf530-ceca-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
         }
@@ -7240,7 +7273,7 @@ class CancelTender:
                         "documentType": "contractArrangements",
                         "title": "create Pn: tender.documents[0].title",
                         "description": "create Pn: tender.documents[0].description",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_one_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [first_lot_id]
@@ -7250,7 +7283,7 @@ class CancelTender:
                         "documentType": "contractArrangements",
                         "title": "create Pn: tender.documents[1].title",
                         "description": "create Pn: tender.documents[1].description",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_two_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [second_lot_id]
@@ -7279,7 +7312,7 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
         json_notice_release_ev = {
@@ -7765,7 +7798,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[0].title",
                     "description": "create Pn: tender.documents[0].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_one_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_one_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
                 }, {
@@ -7773,7 +7806,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[1].title",
                     "description": "create Pn: tender.documents[1].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_two_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_two_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [second_lot_id]
                 }, {
@@ -7781,7 +7814,7 @@ class CancelTender:
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
                     "description": "create CNonPN: tender.documents[2].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
@@ -7801,7 +7834,7 @@ class CancelTender:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 100.00,
                                 "currency": "EUR"
@@ -7814,7 +7847,7 @@ class CancelTender:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 10.00,
                                 "currency": "EUR"
@@ -7833,13 +7866,13 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "164cf531-ceca-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
         json_notice_compiled_release_ms = {
@@ -8162,7 +8195,7 @@ class CancelTender:
                             "title": "create CNonPN: procuringEntity.persones[0].businessFunctions[0].title",
                             "description": "create CNonPN: procuringEntity.persones[0].businessFunctions[0]."
                                            "description",
-                            "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                            "url": f"{instance_storage_url}"
                                    f"{self.document_three_was_uploaded}",
                             "datePublished": operation_date
                         }]
@@ -8175,26 +8208,26 @@ class CancelTender:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "ed0f7290-cee4-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
 
@@ -8399,7 +8432,7 @@ class CancelTender:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_one_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [first_lot_id]
@@ -8409,7 +8442,7 @@ class CancelTender:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_two_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [second_lot_id]
@@ -8438,7 +8471,7 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
         json_notice_compiled_release_ev = {
@@ -8924,7 +8957,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[0].title",
                     "description": "create Pn: tender.documents[0].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_one_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_one_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
                 }, {
@@ -8932,7 +8965,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[1].title",
                     "description": "create Pn: tender.documents[1].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_two_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_two_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [second_lot_id]
                 }, {
@@ -8940,7 +8973,7 @@ class CancelTender:
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
                     "description": "create CNonPN: tender.documents[2].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
@@ -8960,7 +8993,7 @@ class CancelTender:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 100.00,
                                 "currency": "EUR"
@@ -8973,7 +9006,7 @@ class CancelTender:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 10.00,
                                 "currency": "EUR"
@@ -8992,13 +9025,13 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "ed0f7291-cee4-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
 
@@ -9058,10 +9091,10 @@ class CancelTender:
             f"INSERT INTO notice_compiled_release (cp_id,oc_id, json_data, publish_date, release_date, "
             f"release_id, stage, status) VALUES ('{cp_id}', '{ev_id}', '{json.dumps(json_notice_compiled_release_ev)}',"
             f"{ev_id[32:45]},{ev_id[32:45]}, '{ev_id + '-' + ev_id[32:45]}','EV', 'active');").one()
-        record = f"http://dev.public.eprocurement.systems/tenders/{cp_id}"
-        ms_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
-        pn_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
-        ev_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+        record = f"{instance_tender_url}{cp_id}"
+        ms_release = f"{instance_tender_url}{cp_id}/{cp_id}"
+        pn_release = f"{instance_tender_url}{cp_id}/{pn_id}"
+        ev_release = f"{instance_tender_url}{cp_id}/{ev_id}"
         return cp_id, pn_id, pn_token, ev_id, record, ms_release, pn_release, ev_release
 
     @allure.step('Insert CnOnPn: based on FS: treasury - obligatory, based on EI: without items - obligatory')
@@ -9130,6 +9163,17 @@ class CancelTender:
 
         procurement_method_details_from_mdm = data_pn["data"]["tender"]["procurementMethodDetails"]
         eligibility_criteria_from_mdm = data_pn["data"]["tender"]["eligibilityCriteria"]
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if self.instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if self.instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid1()}",
@@ -9664,26 +9708,26 @@ class CancelTender:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/o{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/o{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "164cf530-ceca-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
         }
@@ -9731,7 +9775,7 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
         json_notice_release_ev = {
@@ -9911,7 +9955,7 @@ class CancelTender:
                     "id": self.document_three_was_uploaded,
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date
                 }],
@@ -9931,13 +9975,13 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "164cf531-ceca-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
         json_notice_compiled_release_ms = {
@@ -10153,26 +10197,26 @@ class CancelTender:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "ed0f7290-cee4-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
 
@@ -10220,7 +10264,7 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}/{cp_id}/{cp_id}"
             }]
         }
         json_notice_compiled_release_ev = {
@@ -10400,7 +10444,7 @@ class CancelTender:
                     "id": self.document_three_was_uploaded,
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date
                 }],
@@ -10420,13 +10464,13 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "ed0f7291-cee4-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
 
@@ -10482,10 +10526,10 @@ class CancelTender:
             f"INSERT INTO notice_compiled_release (cp_id,oc_id, json_data, publish_date, release_date, "
             f"release_id, stage, status) VALUES ('{cp_id}', '{ev_id}', '{json.dumps(json_notice_compiled_release_ev)}',"
             f"{ev_id[32:45]},{ev_id[32:45]}, '{ev_id + '-' + ev_id[32:45]}','EV', 'active');").one()
-        record = f"http://dev.public.eprocurement.systems/tenders/{cp_id}"
-        ms_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
-        pn_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
-        ev_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+        record = f"{instance_tender_url}{cp_id}"
+        ms_release = f"{instance_tender_url}{cp_id}/{cp_id}"
+        pn_release = f"{instance_tender_url}{cp_id}/{pn_id}"
+        ev_release = f"{instance_tender_url}{cp_id}/{ev_id}"
         return cp_id, pn_id, pn_token, ev_id, record, ms_release, pn_release, ev_release
 
     @allure.step('Insert CnOnPn: based on FS: own - full, based on EI: with items - full')
@@ -10558,6 +10602,17 @@ class CancelTender:
 
         procurement_method_details_from_mdm = data_pn["data"]["tender"]["procurementMethodDetails"]
         eligibility_criteria_from_mdm = data_pn["data"]["tender"]["eligibilityCriteria"]
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if self.instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if self.instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
         json_orchestrator_context = {
             "cpid": cp_id,
             "ocid": ev_id,
@@ -11281,7 +11336,7 @@ class CancelTender:
                     "startDate": auction_date
                 },
                 "modalities": [{
-                    "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
+                    "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
                     "eligibleMinimumDifference": {
                         "amount": 100.00,
                         "currency": "EUR"
@@ -11294,7 +11349,7 @@ class CancelTender:
                     "startDate": auction_date
                 },
                 "modalities": [{
-                    "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
+                    "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
                     "eligibleMinimumDifference": {
                         "amount": 10.00,
                         "currency": "EUR"
@@ -11646,7 +11701,7 @@ class CancelTender:
                             "title": "create CNonPN: procuringEntity.persones[0].businessFunctions[0].title",
                             "description": "create CNonPN: procuringEntity.persones[0].businessFunctions[0]."
                                            "description",
-                            "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                            "url": f"{instance_storage_url}"
                                    f"{self.document_three_was_uploaded}",
                             "datePublished": operation_date
                         }]
@@ -11659,26 +11714,26 @@ class CancelTender:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/o{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/o{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "164cf530-ceca-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
         }
@@ -11882,7 +11937,7 @@ class CancelTender:
                         "documentType": "contractArrangements",
                         "title": "create Pn: tender.documents[0].title",
                         "description": "create Pn: tender.documents[0].description",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_one_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [first_lot_id]
@@ -11892,7 +11947,7 @@ class CancelTender:
                         "documentType": "contractArrangements",
                         "title": "create Pn: tender.documents[1].title",
                         "description": "create Pn: tender.documents[1].description",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_two_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [second_lot_id]
@@ -11921,7 +11976,7 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
         json_notice_release_ev = {
@@ -12407,7 +12462,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[0].title",
                     "description": "create Pn: tender.documents[0].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_one_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_one_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
                 }, {
@@ -12415,7 +12470,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[1].title",
                     "description": "create Pn: tender.documents[1].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_two_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_two_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [second_lot_id]
                 }, {
@@ -12423,7 +12478,7 @@ class CancelTender:
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
                     "description": "create CNonPN: tender.documents[2].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
@@ -12443,7 +12498,7 @@ class CancelTender:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 100.00,
                                 "currency": "EUR"
@@ -12456,7 +12511,7 @@ class CancelTender:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 10.00,
                                 "currency": "EUR"
@@ -12475,13 +12530,13 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "164cf531-ceca-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
 
@@ -12977,7 +13032,7 @@ class CancelTender:
                         "id": self.document_five_was_uploaded,
                         "title": "cancel_tender: amendments[0].documents[0].title",
                         "description": "cancel_tender: amendments[0].documents[0].description",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_five_was_uploaded}",
                         "datePublished": period[0]
                     }]
@@ -12987,7 +13042,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[0].title",
                     "description": "create Pn: tender.documents[0].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_one_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_one_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
                 }, {
@@ -12995,7 +13050,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[1].title",
                     "description": "create Pn: tender.documents[1].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_two_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [second_lot_id]
@@ -13004,7 +13059,7 @@ class CancelTender:
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
                     "description": "create CNonPN: tender.documents[2].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
@@ -13024,7 +13079,7 @@ class CancelTender:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 100.00,
                                 "currency": "EUR"
@@ -13037,7 +13092,7 @@ class CancelTender:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 10.00,
                                 "currency": "EUR"
@@ -13056,13 +13111,13 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "164cf531-ceca-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
 
@@ -13386,7 +13441,7 @@ class CancelTender:
                             "title": "create CNonPN: procuringEntity.persones[0].businessFunctions[0].title",
                             "description": "create CNonPN: procuringEntity.persones[0].businessFunctions[0]."
                                            "description",
-                            "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                            "url": f"{instance_storage_url}"
                                    f"{self.document_three_was_uploaded}",
                             "datePublished": operation_date
                         }]
@@ -13399,26 +13454,26 @@ class CancelTender:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "ed0f7290-cee4-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
 
@@ -13623,7 +13678,7 @@ class CancelTender:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_one_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [first_lot_id]
@@ -13633,7 +13688,7 @@ class CancelTender:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_two_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [second_lot_id]
@@ -13662,7 +13717,7 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
         json_notice_compiled_release_ev = {
@@ -14157,7 +14212,7 @@ class CancelTender:
                         "id": self.document_five_was_uploaded,
                         "title": "cancel_tender: amendments[0].documents[0].title",
                         "description": "cancel_tender: amendments[0].documents[0].description",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_five_was_uploaded}",
                         "datePublished": period[0]
                     }]
@@ -14167,7 +14222,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[0].title",
                     "description": "create Pn: tender.documents[0].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_one_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_one_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
                 }, {
@@ -14175,7 +14230,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[1].title",
                     "description": "create Pn: tender.documents[1].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_two_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [second_lot_id]
@@ -14184,7 +14239,7 @@ class CancelTender:
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
                     "description": "create CNonPN: tender.documents[2].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
@@ -14204,7 +14259,7 @@ class CancelTender:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 100.00,
                                 "currency": "EUR"
@@ -14217,7 +14272,7 @@ class CancelTender:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 10.00,
                                 "currency": "EUR"
@@ -14236,13 +14291,13 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "ed0f7291-cee4-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}/{cp_id}/{pn_id}"
             }]
         }
 
@@ -14316,10 +14371,10 @@ class CancelTender:
             f"release_id, stage, status) VALUES ('{cp_id}', '{ev_id}', '{json.dumps(json_notice_compiled_release_ev)}',"
             f"{period[2]},{period_for_amendment[1]}, '{ev_id + '-' + str(period_for_amendment[1])}','EV', "
             f"'active');").one()
-        record = f"http://dev.public.eprocurement.systems/tenders/{cp_id}"
-        ms_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
-        pn_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
-        ev_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+        record = f"{instance_tender_url}{cp_id}"
+        ms_release = f"{instance_tender_url}{cp_id}/{cp_id}"
+        pn_release = f"{instance_tender_url}{cp_id}/{pn_id}"
+        ev_release = f"{instance_tender_url}{cp_id}/{ev_id}"
         return cp_id, pn_id, pn_token, ev_id, record, ms_release, pn_release, ev_release, self.amendment_id, \
                self.amendment_token
 
@@ -14391,6 +14446,17 @@ class CancelTender:
 
         procurement_method_details_from_mdm = data_pn["data"]["tender"]["procurementMethodDetails"]
         eligibility_criteria_from_mdm = data_pn["data"]["tender"]["eligibilityCriteria"]
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if self.instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if self.instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
         json_orchestrator_context = {
             "cpid": cp_id,
             "ocid": ev_id,
@@ -14933,26 +14999,26 @@ class CancelTender:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/o{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/o{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "164cf530-ceca-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
         }
@@ -15000,7 +15066,7 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
         json_notice_release_ev = {
@@ -15180,7 +15246,7 @@ class CancelTender:
                     "id": self.document_three_was_uploaded,
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date
                 }],
@@ -15200,13 +15266,13 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "164cf531-ceca-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
         json_notice_release_ev_new = {
@@ -15397,7 +15463,7 @@ class CancelTender:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[0].title",
                     "description": "create Pn: tender.documents[0].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_one_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_one_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
                 }],
@@ -15417,13 +15483,13 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "164cf531-ceca-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
         json_notice_compiled_release_ms = {
@@ -15639,26 +15705,26 @@ class CancelTender:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "ed0f7290-cee4-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
 
@@ -15706,7 +15772,7 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
         json_notice_compiled_release_ev = {
@@ -15895,7 +15961,7 @@ class CancelTender:
                     "id": self.document_one_was_uploaded,
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[0].title",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_one_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_one_was_uploaded}",
                     "datePublished": operation_date
                 }],
                 "awardCriteria": "ratedCriteria",
@@ -15914,13 +15980,13 @@ class CancelTender:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "ed0f7291-cee4-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
 
@@ -15990,9 +16056,9 @@ class CancelTender:
             f"release_id, stage, status) VALUES ('{cp_id}', '{ev_id}', '{json.dumps(json_notice_compiled_release_ev)}',"
             f"{period[2]},{period_for_amendment[1]}, '{ev_id + '-' + str(period_for_amendment[1])}','EV', "
             f"'active');").one()
-        record = f"http://dev.public.eprocurement.systems/tenders/{cp_id}"
-        ms_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
-        pn_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
-        ev_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+        record = f"{instance_tender_url}{cp_id}"
+        ms_release = f"{instance_tender_url}{cp_id}/{cp_id}"
+        pn_release = f"{instance_tender_url}{cp_id}/{pn_id}"
+        ev_release = f"{instance_tender_url}{cp_id}/{ev_id}"
         return cp_id, pn_id, pn_token, ev_id, record, ms_release, pn_release, ev_release, self.amendment_id, \
                self.amendment_token

--- a/tests/essences/cancel_tender.py
+++ b/tests/essences/cancel_tender.py
@@ -361,6 +361,7 @@ class CancelTender:
         auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)
         cluster = Cluster([self.cassandra_cluster], auth_provider=auth_provider)
         key_space_ocds = cluster.connect('ocds')
+        key_space_access = cluster.connect('access')
         key_space_clarification = cluster.connect('clarification')
         key_space_submission = cluster.connect('submission')
         key_space_auctions = cluster.connect('auctions')
@@ -4127,9 +4128,9 @@ class CancelTender:
 
         key_space_ocds.execute(f"INSERT INTO orchestrator_context (cp_id,context) VALUES ("
                                f"'{ev_id}','{json.dumps(json_orchestrator_context)}');").one()
-        key_space_ocds.execute(f"INSERT INTO access_tender (cpid, ocid, token_entity,created_date,json_data, owner) "
-                               f"VALUES ('{cp_id}', '{ev_id}', {pn_token}, {ev_id[32:45]}, "
-                               f"'{json.dumps(json_access_tender)}','{owner}');").one()
+        key_space_access.execute(f"INSERT INTO tenders (cpid, ocid, token_entity,created_date,json_data, owner) "
+                                 f"VALUES ('{cp_id}', '{ev_id}', '{pn_token}', {ev_id[32:45]}, "
+                                 f"'{json.dumps(json_access_tender)}','{owner}');").one()
         key_space_auctions.execute(
             f"INSERT INTO auctions (cpid, ocid, api_version, country, data, operation_id, row_version, status ) "
             f"VALUES ('{cp_id}', '{ev_id}', '1.0.0', '{self.country}', '{json.dumps(json_auction_auctions)}', "
@@ -4195,6 +4196,7 @@ class CancelTender:
         auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)
         cluster = Cluster([self.cassandra_cluster], auth_provider=auth_provider)
         key_space_ocds = cluster.connect('ocds')
+        key_space_access = cluster.connect('access')
         key_space_clarification = cluster.connect('clarification')
         key_space_submission = cluster.connect('submission')
         key_space_revision = cluster.connect('revision')
@@ -5804,9 +5806,9 @@ class CancelTender:
 
         key_space_ocds.execute(f"INSERT INTO orchestrator_context (cp_id,context) VALUES ("
                                f"'{ev_id}','{json.dumps(json_orchestrator_context)}');").one()
-        key_space_ocds.execute(f"INSERT INTO access_tender (cpid, ocid, token_entity,created_date,json_data, owner) "
-                               f"VALUES ('{cp_id}', '{ev_id}', {pn_token}, {ev_id[32:45]}, "
-                               f"'{json.dumps(json_access_tender)}','{owner}');").one()
+        key_space_access.execute(f"INSERT INTO tenders (cpid, ocid, token_entity,created_date,json_data, owner) "
+                                 f"VALUES ('{cp_id}', '{ev_id}', '{pn_token}', {ev_id[32:45]}, "
+                                 f"'{json.dumps(json_access_tender)}','{owner}');").one()
         key_space_clarification.execute(
             f"INSERT INTO periods (cpid, ocid, end_date, owner, start_date) "
             f"VALUES ('{cp_id}', '{ev_id}', {get_timestamp_from_human_date(enquiry_and_tender_period[1])}, '{owner}', "
@@ -5868,6 +5870,7 @@ class CancelTender:
         auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)
         cluster = Cluster([self.cassandra_cluster], auth_provider=auth_provider)
         key_space_ocds = cluster.connect('ocds')
+        key_space_access = cluster.connect('access')
         key_space_clarification = cluster.connect('clarification')
         key_space_submission = cluster.connect('submission')
         key_space_auctions = cluster.connect('auctions')
@@ -9014,9 +9017,9 @@ class CancelTender:
 
         key_space_ocds.execute(f"INSERT INTO orchestrator_context (cp_id,context) VALUES ("
                                f"'{ev_id}','{json.dumps(json_orchestrator_context)}');").one()
-        key_space_ocds.execute(f"INSERT INTO access_tender (cpid, ocid, token_entity,created_date,json_data, owner) "
-                               f"VALUES ('{cp_id}', '{ev_id}', {pn_token}, {ev_id[32:45]}, "
-                               f"'{json.dumps(json_access_tender)}','{owner}');").one()
+        key_space_access.execute(f"INSERT INTO tenders (cpid, ocid, token_entity,created_date,json_data, owner) "
+                                 f"VALUES ('{cp_id}', '{ev_id}', '{pn_token}', {ev_id[32:45]}, "
+                                 f"'{json.dumps(json_access_tender)}','{owner}');").one()
         key_space_auctions.execute(
             f"INSERT INTO auctions (cpid, ocid, api_version, country, data, operation_id, row_version, status ) "
             f"VALUES ('{cp_id}', '{ev_id}', '1.0.0', '{self.country}', '{json.dumps(json_auction_auctions)}', "
@@ -9067,6 +9070,7 @@ class CancelTender:
         auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)
         cluster = Cluster([self.cassandra_cluster], auth_provider=auth_provider)
         key_space_ocds = cluster.connect('ocds')
+        key_space_access = cluster.connect('access')
         key_space_clarification = cluster.connect('clarification')
         key_space_submission = cluster.connect('submission')
         owner = "445f6851-c908-407d-9b45-14b92f3e964b"
@@ -10441,9 +10445,9 @@ class CancelTender:
 
         key_space_ocds.execute(f"INSERT INTO orchestrator_context (cp_id,context) VALUES ("
                                f"'{ev_id}','{json.dumps(json_orchestrator_context)}');").one()
-        key_space_ocds.execute(f"INSERT INTO access_tender (cpid, ocid, token_entity,created_date,json_data, owner) "
-                               f"VALUES ('{cp_id}', '{ev_id}', {pn_token}, {ev_id[32:45]}, "
-                               f"'{json.dumps(json_access_tender)}','{owner}');").one()
+        key_space_access.execute(f"INSERT INTO tenders (cpid, ocid, token_entity,created_date,json_data, owner) "
+                                 f"VALUES ('{cp_id}', '{ev_id}', '{pn_token}', {ev_id[32:45]}, "
+                                 f"'{json.dumps(json_access_tender)}','{owner}');").one()
         key_space_clarification.execute(
             f"INSERT INTO periods (cpid, ocid, end_date, owner, start_date) "
             f"VALUES ('{cp_id}', '{ev_id}', {get_timestamp_from_human_date(enquiry_and_tender_period[1])}, '{owner}', "
@@ -10490,6 +10494,7 @@ class CancelTender:
         auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)
         cluster = Cluster([self.cassandra_cluster], auth_provider=auth_provider)
         key_space_ocds = cluster.connect('ocds')
+        key_space_access = cluster.connect('access')
         key_space_clarification = cluster.connect('clarification')
         key_space_submission = cluster.connect('submission')
         key_space_auctions = cluster.connect('auctions')
@@ -14256,9 +14261,9 @@ class CancelTender:
 
         key_space_ocds.execute(f"INSERT INTO orchestrator_context (cp_id,context) VALUES ("
                                f"'{ev_id}','{json.dumps(json_orchestrator_context)}');").one()
-        key_space_ocds.execute(f"INSERT INTO access_tender (cpid, ocid, token_entity,created_date,json_data, owner) "
-                               f"VALUES ('{cp_id}', '{ev_id}', {pn_token}, {ev_id[32:45]}, "
-                               f"'{json.dumps(json_access_tender)}','{owner}');").one()
+        key_space_access.execute(f"INSERT INTO tenders (cpid, ocid, token_entity,created_date,json_data, owner) "
+                                 f"VALUES ('{cp_id}', '{ev_id}', '{pn_token}', {ev_id[32:45]}, "
+                                 f"'{json.dumps(json_access_tender)}','{owner}');").one()
         key_space_auctions.execute(
             f"INSERT INTO auctions (cpid, ocid, api_version, country, data, operation_id, row_version, status ) "
             f"VALUES ('{cp_id}', '{ev_id}', '1.0.0', '{self.country}', '{json.dumps(json_auction_auctions)}', "
@@ -14324,6 +14329,7 @@ class CancelTender:
         auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)
         cluster = Cluster([self.cassandra_cluster], auth_provider=auth_provider)
         key_space_ocds = cluster.connect('ocds')
+        key_space_access = cluster.connect('access')
         key_space_clarification = cluster.connect('clarification')
         key_space_submission = cluster.connect('submission')
         key_space_revision = cluster.connect('revision')
@@ -15933,9 +15939,9 @@ class CancelTender:
 
         key_space_ocds.execute(f"INSERT INTO orchestrator_context (cp_id,context) VALUES ("
                                f"'{ev_id}','{json.dumps(json_orchestrator_context)}');").one()
-        key_space_ocds.execute(f"INSERT INTO access_tender (cpid, ocid, token_entity,created_date,json_data, owner) "
-                               f"VALUES ('{cp_id}', '{ev_id}', {pn_token}, {ev_id[32:45]}, "
-                               f"'{json.dumps(json_access_tender)}','{owner}');").one()
+        key_space_access.execute(f"INSERT INTO tenders (cpid, ocid, token_entity,created_date,json_data, owner) "
+                                 f"VALUES ('{cp_id}', '{ev_id}', '{pn_token}', {ev_id[32:45]}, "
+                                 f"'{json.dumps(json_access_tender)}','{owner}');").one()
         key_space_clarification.execute(
             f"INSERT INTO periods (cpid, ocid, end_date, owner, start_date) "
             f"VALUES ('{cp_id}', '{ev_id}', {get_timestamp_from_human_date(enquiry_and_tender_period[1])}, '{owner}', "

--- a/tests/essences/cn.py
+++ b/tests/essences/cn.py
@@ -265,18 +265,18 @@ class CN:
         return message_from_kafka
 
     def check_on_that_message_is_successfully_create_cn(self):
-        instance_url = None
+        instance_tender_url = None
         if self.instance == "dev":
-            instance_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
         if self.instance == "sandbox":
-            instance_url = "http://public.eprocurement.systems/tenders/"
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
         message = get_message_from_kafka(self.x_operation_id)
         check_x_operation_id = is_it_uuid(message["X-OPERATION-ID"], 4)
         check_x_response_id = is_it_uuid(message["X-RESPONSE-ID"], 1)
         check_initiator = fnmatch.fnmatch(message["initiator"], "platform")
         check_oc_id = fnmatch.fnmatch(message["data"]["ocid"], "ocds-t1s2t3-MD-*")
         check_url = fnmatch.fnmatch(message["data"]["url"],
-                                    f"{instance_url}{message['data']['ocid']}")
+                                    f"{instance_tender_url}{message['data']['ocid']}")
         check_operation_date = fnmatch.fnmatch(message["data"]["operationDate"], "202*-*-*T*:*:*Z")
         check_ev_id = fnmatch.fnmatch(message["data"]["outcomes"]["ev"][0]["id"], f"{message['data']['ocid']}-EV-*")
         for i in message["data"]["outcomes"]["ev"][0].keys():
@@ -289,18 +289,18 @@ class CN:
             return False
 
     def check_on_that_message_is_successfully_update_cn(self, cp_id, ev_id):
-        instance_url = None
+        instance_tender_url = None
         if self.instance == "dev":
-            instance_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
         if self.instance == "sandbox":
-            instance_url = "http://public.eprocurement.systems/tenders/"
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
         message = get_message_from_kafka(self.x_operation_id)
         check_x_operation_id = is_it_uuid(message["X-OPERATION-ID"], 4)
         check_x_response_id = is_it_uuid(message["X-RESPONSE-ID"], 1)
         check_initiator = fnmatch.fnmatch(message["initiator"], "platform")
         check_oc_id = fnmatch.fnmatch(message["data"]["ocid"], f"{ev_id}")
         check_url = fnmatch.fnmatch(message["data"]["url"],
-                                    f"{instance_url}{cp_id}/{ev_id}")
+                                    f"{instance_tender_url}{cp_id}/{ev_id}")
         check_operation_date = fnmatch.fnmatch(message["data"]["operationDate"], "202*-*-*T*:*:*Z")
         check_amendments = is_it_uuid(message["data"]['outcomes']['amendments'][0]['id'], 4)
         if check_x_operation_id is True and check_x_response_id is True and check_initiator is True and \
@@ -371,6 +371,17 @@ class CN:
         procurement_method_details_from_mdm = data_pn["data"]["tender"]["procurementMethodDetails"]
         eligibility_criteria_from_mdm = data_pn["data"]["tender"]["eligibilityCriteria"]
 
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if self.instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if self.instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid4()}",
@@ -1183,7 +1194,7 @@ class CN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
                 },
                 {
                     "id": "31bd7be0-c23c-11eb-ab87-09e4e5e94b2a",
@@ -1191,7 +1202,7 @@ class CN:
                         "x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -1344,7 +1355,7 @@ class CN:
                         "parent"],
                     "scheme": "ocid",
                     "identifier": ei_id,
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
                 },
                 {
                     "id": "31bda2f0-c23c-11eb-ab87-09e4e5e94b2a",
@@ -1352,7 +1363,7 @@ class CN:
                         "x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -1505,14 +1516,14 @@ class CN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
                 },
                 {
                     "id": "ce7f5070-c057-11eb-ab87-09e4e5e94b2a",
                     "relationship": ["x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -1666,14 +1677,14 @@ class CN:
                         "parent"],
                     "scheme": "ocid",
                     "identifier": f"{ei_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
                 },
                 {
                     "id": "ce7f7780-c057-11eb-ab87-09e4e5e94b2a",
                     "relationship": ["x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -1976,19 +1987,19 @@ class CN:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/o{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/o{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             }]
         }
 
@@ -2192,7 +2203,7 @@ class CN:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_one_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [first_lot_id]
@@ -2202,7 +2213,7 @@ class CN:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_two_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [second_lot_id]
@@ -2231,7 +2242,7 @@ class CN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -2528,19 +2539,19 @@ class CN:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             }]
 
         }
@@ -2745,7 +2756,7 @@ class CN:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_one_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [first_lot_id]
@@ -2755,7 +2766,7 @@ class CN:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_two_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [second_lot_id]
@@ -2784,7 +2795,7 @@ class CN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -2840,9 +2851,9 @@ class CN:
 
         session.execute(f"INSERT INTO notice_offset (cp_id,release_date, stage, status) "
                         f"VALUES ('{cp_id}', {pn_id[32:45]}, 'PN', 'planning');").one()
-        pn_record = f"http://dev.public.eprocurement.systems/tenders/{cp_id}"
-        ms_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
-        pn_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+        pn_record = f"{instance_tender_url}{cp_id}"
+        ms_release = f"{instance_tender_url}{cp_id}/{cp_id}"
+        pn_release = f"{instance_tender_url}{cp_id}/{pn_id}"
         return ei_id, ei_token, fs_id, fs_token, cp_id, pn_id, pn_token, pn_record, ms_release, pn_release
 
     @allure.step('Insert PN: based on FS: treasury - obligatory, based on EI: without items - obligatory')
@@ -2874,7 +2885,14 @@ class CN:
         submission_method_rationale = data_pn["data"]["tender"]["submissionMethodRationale"]
         procurement_method_details_from_mdm = data_pn["data"]["tender"]["procurementMethodDetails"]
         eligibility_criteria_from_mdm = data_pn["data"]["tender"]["eligibilityCriteria"]
-
+        instance_tender_url = None
+        instance_budget_url = None
+        if self.instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid4()}",
@@ -3265,7 +3283,7 @@ class CN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
                 },
                 {
                     "id": "31bd7be0-c23c-11eb-ab87-09e4e5e94b2a",
@@ -3273,7 +3291,7 @@ class CN:
                         "x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -3354,7 +3372,7 @@ class CN:
                         "parent"],
                     "scheme": "ocid",
                     "identifier": ei_id,
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
                 },
                 {
                     "id": "31bda2f0-c23c-11eb-ab87-09e4e5e94b2a",
@@ -3362,7 +3380,7 @@ class CN:
                         "x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -3451,14 +3469,14 @@ class CN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
                 },
                 {
                     "id": "ce7f5070-c057-11eb-ab87-09e4e5e94b2a",
                     "relationship": ["x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -3540,14 +3558,14 @@ class CN:
                         "parent"],
                     "scheme": "ocid",
                     "identifier": f"{ei_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
                 },
                 {
                     "id": "ce7f7780-c057-11eb-ab87-09e4e5e94b2a",
                     "relationship": ["x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -3750,19 +3768,19 @@ class CN:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/o{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/o{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             }]
         }
 
@@ -3809,7 +3827,7 @@ class CN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -4010,19 +4028,19 @@ class CN:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             }]
 
         }
@@ -4070,7 +4088,7 @@ class CN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -4127,9 +4145,9 @@ class CN:
         session.execute(f"INSERT INTO notice_offset (cp_id,release_date, stage, status) "
                         f"VALUES ('{cp_id}', {pn_id[32:45]}, 'PN', 'planning');").one()
 
-        pn_record = f"http://dev.public.eprocurement.systems/tenders/{cp_id}"
-        ms_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
-        pn_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+        pn_record = f"{instance_tender_url}{cp_id}"
+        ms_release = f"{instance_tender_url}{cp_id}/{cp_id}"
+        pn_release = f"{instance_tender_url}{cp_id}/{pn_id}"
         return ei_id, ei_token, fs_id, fs_token, cp_id, pn_id, pn_token, pn_record, ms_release, pn_release
 
     @allure.step('Insert CnOnPn: based on FS: own - full, based on EI: with items - full')
@@ -4138,7 +4156,7 @@ class CN:
         auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)
         cluster = Cluster([self.cassandra_cluster], auth_provider=auth_provider)
         key_space_ocds = cluster.connect('ocds')
-        key_space_access = cluster.connect('ocds')
+        key_space_access = cluster.connect('access')
         key_space_clarification = cluster.connect('clarification')
         key_space_submission = cluster.connect('submission')
         key_space_auctions = cluster.connect('auctions')
@@ -4200,6 +4218,17 @@ class CN:
 
         procurement_method_details_from_mdm = data_pn["data"]["tender"]["procurementMethodDetails"]
         eligibility_criteria_from_mdm = data_pn["data"]["tender"]["eligibilityCriteria"]
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if self.instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if self.instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid1()}",
@@ -4925,7 +4954,7 @@ class CN:
                     "startDate": auction_date
                 },
                 "modalities": [{
-                    "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
+                    "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
                     "eligibleMinimumDifference": {
                         "amount": 100.00,
                         "currency": "EUR"
@@ -4938,7 +4967,7 @@ class CN:
                     "startDate": auction_date
                 },
                 "modalities": [{
-                    "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
+                    "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
                     "eligibleMinimumDifference": {
                         "amount": 10.00,
                         "currency": "EUR"
@@ -5272,7 +5301,7 @@ class CN:
                             "title": "create CNonPN: procuringEntity.persones[0].businessFunctions[0].title",
                             "description": "create CNonPN: procuringEntity.persones[0].businessFunctions[0]."
                                            "description",
-                            "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                            "url": f"{instance_storage_url}"
                                    f"{self.document_three_was_uploaded}",
                             "datePublished": operation_date
                         }]
@@ -5285,26 +5314,26 @@ class CN:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/o{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/o{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "164cf530-ceca-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
         }
@@ -5508,7 +5537,7 @@ class CN:
                         "documentType": "contractArrangements",
                         "title": "create Pn: tender.documents[0].title",
                         "description": "create Pn: tender.documents[0].description",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_one_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [first_lot_id]
@@ -5518,7 +5547,7 @@ class CN:
                         "documentType": "contractArrangements",
                         "title": "create Pn: tender.documents[1].title",
                         "description": "create Pn: tender.documents[1].description",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_two_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [second_lot_id]
@@ -5547,7 +5576,7 @@ class CN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
         json_notice_release_ev = {
@@ -6033,7 +6062,7 @@ class CN:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[0].title",
                     "description": "create Pn: tender.documents[0].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_one_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_one_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
                 }, {
@@ -6041,7 +6070,7 @@ class CN:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[1].title",
                     "description": "create Pn: tender.documents[1].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_two_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_two_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [second_lot_id]
                 }, {
@@ -6049,7 +6078,7 @@ class CN:
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
                     "description": "create CNonPN: tender.documents[2].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
@@ -6069,7 +6098,7 @@ class CN:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 100.00,
                                 "currency": "EUR"
@@ -6082,7 +6111,7 @@ class CN:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 10.00,
                                 "currency": "EUR"
@@ -6101,13 +6130,13 @@ class CN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "164cf531-ceca-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
         json_notice_compiled_release_ms = {
@@ -6430,7 +6459,7 @@ class CN:
                             "title": "create CNonPN: procuringEntity.persones[0].businessFunctions[0].title",
                             "description": "create CNonPN: procuringEntity.persones[0].businessFunctions[0]."
                                            "description",
-                            "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                            "url": f"{instance_storage_url}"
                                    f"{self.document_three_was_uploaded}",
                             "datePublished": operation_date
                         }]
@@ -6443,26 +6472,26 @@ class CN:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "ed0f7290-cee4-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
 
@@ -6667,7 +6696,7 @@ class CN:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_one_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [first_lot_id]
@@ -6677,7 +6706,7 @@ class CN:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_two_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [second_lot_id]
@@ -6706,7 +6735,7 @@ class CN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
         json_notice_compiled_release_ev = {
@@ -7192,7 +7221,7 @@ class CN:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[0].title",
                     "description": "create Pn: tender.documents[0].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_one_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_one_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
                 }, {
@@ -7200,7 +7229,7 @@ class CN:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[1].title",
                     "description": "create Pn: tender.documents[1].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_two_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_two_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [second_lot_id]
                 }, {
@@ -7208,7 +7237,7 @@ class CN:
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
                     "description": "create CNonPN: tender.documents[2].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
@@ -7228,7 +7257,7 @@ class CN:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 100.00,
                                 "currency": "EUR"
@@ -7241,7 +7270,7 @@ class CN:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 10.00,
                                 "currency": "EUR"
@@ -7260,13 +7289,13 @@ class CN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "ed0f7291-cee4-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
 
@@ -7327,10 +7356,10 @@ class CN:
             f"INSERT INTO notice_compiled_release (cp_id,oc_id, json_data, publish_date, release_date, "
             f"release_id, stage, status) VALUES ('{cp_id}', '{ev_id}', '{json.dumps(json_notice_compiled_release_ev)}',"
             f"{ev_id[32:45]},{ev_id[32:45]}, '{ev_id + '-' + ev_id[32:45]}','EV', 'active');").one()
-        record = f"http://dev.public.eprocurement.systems/tenders/{cp_id}"
-        ms_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
-        pn_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
-        ev_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+        record = f"{instance_tender_url}{cp_id}"
+        ms_release = f"{instance_tender_url}{cp_id}/{cp_id}"
+        pn_release = f"{instance_tender_url}{cp_id}/{pn_id}"
+        ev_release = f"{instance_tender_url}{cp_id}/{ev_id}"
         return cp_id, pn_id, pn_token, ev_id, record, ms_release, pn_release, ev_release, \
                enquiry_and_tender_period[0], enquiry_and_tender_period[1], enquiry_and_tender_period[2], \
                enquiry_and_tender_period[3]
@@ -7401,6 +7430,17 @@ class CN:
 
         procurement_method_details_from_mdm = data_pn["data"]["tender"]["procurementMethodDetails"]
         eligibility_criteria_from_mdm = data_pn["data"]["tender"]["eligibilityCriteria"]
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if self.instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if self.instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid1()}",
@@ -7935,26 +7975,26 @@ class CN:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/o{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/o{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "164cf530-ceca-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
         }
@@ -8002,7 +8042,7 @@ class CN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
         json_notice_release_ev = {
@@ -8182,7 +8222,7 @@ class CN:
                     "id": self.document_three_was_uploaded,
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date
                 }],
@@ -8202,13 +8242,13 @@ class CN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "164cf531-ceca-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
         json_notice_compiled_release_ms = {
@@ -8424,26 +8464,26 @@ class CN:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "ed0f7290-cee4-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
 
@@ -8491,7 +8531,7 @@ class CN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
         json_notice_compiled_release_ev = {
@@ -8671,7 +8711,7 @@ class CN:
                     "id": self.document_three_was_uploaded,
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date
                 }],
@@ -8691,13 +8731,13 @@ class CN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "ed0f7291-cee4-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
 
@@ -8755,8 +8795,8 @@ class CN:
             f"INSERT INTO notice_compiled_release (cp_id,oc_id, json_data, publish_date, release_date, "
             f"release_id, stage, status) VALUES ('{cp_id}', '{ev_id}', '{json.dumps(json_notice_compiled_release_ev)}',"
             f"{ev_id[32:45]},{ev_id[32:45]}, '{ev_id + '-' + ev_id[32:45]}','EV', 'active');").one()
-        record = f"http://dev.public.eprocurement.systems/tenders/{cp_id}"
-        ms_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
-        pn_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
-        ev_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+        record = f"{instance_tender_url}{cp_id}"
+        ms_release = f"{instance_tender_url}{cp_id}/{cp_id}"
+        pn_release = f"{instance_tender_url}{cp_id}/{pn_id}"
+        ev_release = f"{instance_tender_url}{cp_id}/{ev_id}"
         return cp_id, pn_id, pn_token, ev_id, record, ms_release, pn_release, ev_release

--- a/tests/essences/ei.py
+++ b/tests/essences/ei.py
@@ -157,7 +157,7 @@ class EI:
             json=self.payload)
         allure.attach(self.host_of_request + "/do/ei", 'URL')
         allure.attach(json.dumps(self.payload), 'Prepared payload')
-        return ei
+        return ei, self.x_operation_id
 
     @allure.step('Insert EI')
     def insert_ei_full_data_model(self, cp_id, ei_token):

--- a/tests/essences/enquiry.py
+++ b/tests/essences/enquiry.py
@@ -286,6 +286,7 @@ class Enquiry:
                            second_tender, second_enquiry):
         auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)
         cluster = Cluster([self.cassandra_cluster], auth_provider=auth_provider)
+
         key_space_ocds = cluster.connect('ocds')
         key_space_access = cluster.connect('access')
         key_space_clarification = cluster.connect('clarification')
@@ -301,10 +302,6 @@ class Enquiry:
         period = get_period()
         auction_date = get_auction_date()
         contract_period = get_contract_period()
-        enquiry_and_tender_period = create_enquiry_and_tender_period(
-            second_enquiry=second_enquiry,
-            second_tender=second_tender
-        )
 
         operation_date = time_at_now()
         calculate_new_cpv_code = get_new_classification_id(
@@ -349,6 +346,21 @@ class Enquiry:
 
         procurement_method_details_from_mdm = data_pn["data"]["tender"]["procurementMethodDetails"]
         eligibility_criteria_from_mdm = data_pn["data"]["tender"]["eligibilityCriteria"]
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if self.instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if self.instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        enquiry_and_tender_period = create_enquiry_and_tender_period(
+            second_enquiry=second_enquiry,
+            second_tender=second_tender
+        )
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid1()}",
@@ -1074,7 +1086,7 @@ class Enquiry:
                     "startDate": auction_date
                 },
                 "modalities": [{
-                    "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
+                    "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
                     "eligibleMinimumDifference": {
                         "amount": 100.00,
                         "currency": "EUR"
@@ -1087,7 +1099,7 @@ class Enquiry:
                     "startDate": auction_date
                 },
                 "modalities": [{
-                    "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
+                    "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
                     "eligibleMinimumDifference": {
                         "amount": 10.00,
                         "currency": "EUR"
@@ -1421,7 +1433,7 @@ class Enquiry:
                             "title": "create CNonPN: procuringEntity.persones[0].businessFunctions[0].title",
                             "description": "create CNonPN: procuringEntity.persones[0].businessFunctions[0]."
                                            "description",
-                            "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                            "url": f"{instance_storage_url}"
                                    f"{self.document_three_was_uploaded}",
                             "datePublished": operation_date
                         }]
@@ -1434,26 +1446,26 @@ class Enquiry:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/o{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/o{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/o{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/o{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "164cf530-ceca-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
         }
@@ -1657,7 +1669,7 @@ class Enquiry:
                         "documentType": "contractArrangements",
                         "title": "create Pn: tender.documents[0].title",
                         "description": "create Pn: tender.documents[0].description",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_one_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [first_lot_id]
@@ -1667,7 +1679,7 @@ class Enquiry:
                         "documentType": "contractArrangements",
                         "title": "create Pn: tender.documents[1].title",
                         "description": "create Pn: tender.documents[1].description",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_two_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [second_lot_id]
@@ -1696,7 +1708,7 @@ class Enquiry:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
         json_notice_release_ev = {
@@ -2182,7 +2194,7 @@ class Enquiry:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[0].title",
                     "description": "create Pn: tender.documents[0].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_one_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_one_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
                 }, {
@@ -2190,7 +2202,7 @@ class Enquiry:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[1].title",
                     "description": "create Pn: tender.documents[1].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_two_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_two_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [second_lot_id]
                 }, {
@@ -2198,7 +2210,7 @@ class Enquiry:
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
                     "description": "create CNonPN: tender.documents[2].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
@@ -2218,7 +2230,7 @@ class Enquiry:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 100.00,
                                 "currency": "EUR"
@@ -2231,7 +2243,7 @@ class Enquiry:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 10.00,
                                 "currency": "EUR"
@@ -2250,13 +2262,13 @@ class Enquiry:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "164cf531-ceca-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
         json_notice_compiled_release_ms = {
@@ -2579,7 +2591,7 @@ class Enquiry:
                             "title": "create CNonPN: procuringEntity.persones[0].businessFunctions[0].title",
                             "description": "create CNonPN: procuringEntity.persones[0].businessFunctions[0]."
                                            "description",
-                            "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                            "url": f"{instance_storage_url}"
                                    f"{self.document_three_was_uploaded}",
                             "datePublished": operation_date
                         }]
@@ -2592,26 +2604,26 @@ class Enquiry:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "ed0f7290-cee4-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
 
@@ -2816,7 +2828,7 @@ class Enquiry:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_one_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [first_lot_id]
@@ -2826,7 +2838,7 @@ class Enquiry:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_two_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [second_lot_id]
@@ -2855,7 +2867,7 @@ class Enquiry:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
         json_notice_compiled_release_ev = {
@@ -3341,7 +3353,7 @@ class Enquiry:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[0].title",
                     "description": "create Pn: tender.documents[0].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_one_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_one_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
                 }, {
@@ -3349,7 +3361,7 @@ class Enquiry:
                     "documentType": "contractArrangements",
                     "title": "create Pn: tender.documents[1].title",
                     "description": "create Pn: tender.documents[1].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/{self.document_two_was_uploaded}",
+                    "url": f"{instance_storage_url}{self.document_two_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [second_lot_id]
                 }, {
@@ -3357,7 +3369,7 @@ class Enquiry:
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
                     "description": "create CNonPN: tender.documents[2].description",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date,
                     "relatedLots": [first_lot_id]
@@ -3377,7 +3389,7 @@ class Enquiry:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{first_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 100.00,
                                 "currency": "EUR"
@@ -3390,7 +3402,7 @@ class Enquiry:
                             "startDate": auction_date
                         },
                         "electronicAuctionModalities": [{
-                            "url": f"http://auction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
+                            "url": f"https://eauction.eprocurement.systems/auctions/{ev_id}/{second_lot_id}",
                             "eligibleMinimumDifference": {
                                 "amount": 10.00,
                                 "currency": "EUR"
@@ -3409,13 +3421,13 @@ class Enquiry:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "ed0f7291-cee4-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
 
@@ -3475,10 +3487,10 @@ class Enquiry:
             f"INSERT INTO notice_compiled_release (cp_id,oc_id, json_data, publish_date, release_date, "
             f"release_id, stage, status) VALUES ('{cp_id}', '{ev_id}', '{json.dumps(json_notice_compiled_release_ev)}',"
             f"{ev_id[32:45]},{ev_id[32:45]}, '{ev_id + '-' + ev_id[32:45]}','EV', 'active');").one()
-        record = f"http://dev.public.eprocurement.systems/tenders/{cp_id}"
-        ms_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
-        pn_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
-        ev_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+        record = f"{instance_tender_url}{cp_id}"
+        ms_release = f"{instance_tender_url}{cp_id}/{cp_id}"
+        pn_release = f"{instance_tender_url}{cp_id}/{pn_id}"
+        ev_release = f"{instance_tender_url}{cp_id}/{ev_id}"
         return cp_id, pn_id, pn_token, ev_id, record, ms_release, pn_release, ev_release, \
                enquiry_and_tender_period[0], enquiry_and_tender_period[1], enquiry_and_tender_period[2], \
                enquiry_and_tender_period[3]
@@ -3488,6 +3500,7 @@ class Enquiry:
                                  second_tender, second_enquiry):
         auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)
         cluster = Cluster([self.cassandra_cluster], auth_provider=auth_provider)
+
         key_space_ocds = cluster.connect('ocds')
         key_space_access = cluster.connect('access')
         key_space_clarification = cluster.connect('clarification')
@@ -3501,10 +3514,7 @@ class Enquiry:
         ev_id = prepared_cn_oc_id(cp_id)
         period = get_period()
         contract_period = get_contract_period()
-        enquiry_and_tender_period = create_enquiry_and_tender_period(
-            second_enquiry=second_enquiry,
-            second_tender=second_tender
-        )
+
 
         operation_date = time_at_now()
         calculate_new_cpv_code = get_new_classification_id(
@@ -3549,6 +3559,21 @@ class Enquiry:
 
         procurement_method_details_from_mdm = data_pn["data"]["tender"]["procurementMethodDetails"]
         eligibility_criteria_from_mdm = data_pn["data"]["tender"]["eligibilityCriteria"]
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if self.instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if self.instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
+        enquiry_and_tender_period = create_enquiry_and_tender_period(
+            second_enquiry=second_enquiry,
+            second_tender=second_tender
+        )
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid1()}",
@@ -4083,26 +4108,26 @@ class Enquiry:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/o{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/o{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/o{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/o{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "164cf530-ceca-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
         }
@@ -4150,7 +4175,7 @@ class Enquiry:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
         json_notice_release_ev = {
@@ -4330,7 +4355,7 @@ class Enquiry:
                     "id": self.document_three_was_uploaded,
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date
                 }],
@@ -4350,13 +4375,13 @@ class Enquiry:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "164cf531-ceca-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
         json_notice_compiled_release_ms = {
@@ -4572,26 +4597,26 @@ class Enquiry:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             },
                 {
                     "id": "ed0f7290-cee4-11eb-8aed-69d06bed4d57",
                     "relationship": ["x_evaluation"],
                     "scheme": "ocid",
                     "identifier": ev_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{ev_id}"
                 }
             ]
 
@@ -4639,7 +4664,7 @@ class Enquiry:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}/{cp_id}/{cp_id}"
             }]
         }
         json_notice_compiled_release_ev = {
@@ -4819,7 +4844,7 @@ class Enquiry:
                     "id": self.document_three_was_uploaded,
                     "documentType": "illustration",
                     "title": "create CNonPN: tender.documents[2].title",
-                    "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                    "url": f"{instance_storage_url}"
                            f"{self.document_three_was_uploaded}",
                     "datePublished": operation_date
                 }],
@@ -4839,13 +4864,13 @@ class Enquiry:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }, {
                 "id": "ed0f7291-cee4-11eb-8aed-69d06bed4d57",
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }]
         }
 
@@ -4869,11 +4894,13 @@ class Enquiry:
                                  f"'{json.dumps(json_access_tender)}','{owner}');").one()
         key_space_clarification.execute(
             f"INSERT INTO periods (cpid, ocid, end_date, owner, start_date) "
-            f"VALUES ('{cp_id}', '{ev_id}', {get_timestamp_from_human_date_in_gmt_format(enquiry_and_tender_period[1])}, '{owner}', "
+            f"VALUES ('{cp_id}', '{ev_id}', "
+            f"{get_timestamp_from_human_date_in_gmt_format(enquiry_and_tender_period[1])}, '{owner}', "
             f"{ev_id[32:45]});").one()
         key_space_submission.execute(
             f"INSERT INTO periods (cpid, ocid, end_date, start_date) "
-            f"VALUES ('{cp_id}', '{ev_id}', {get_timestamp_from_human_date_in_gmt_format(enquiry_and_tender_period[3])}, "
+            f"VALUES ('{cp_id}', '{ev_id}', "
+            f"{get_timestamp_from_human_date_in_gmt_format(enquiry_and_tender_period[3])}, "
             f"{get_timestamp_from_human_date_in_gmt_format(enquiry_and_tender_period[1])});").one()
         key_space_ocds.execute(f"INSERT INTO notice_offset (cp_id,release_date, stage, status) "
                                f"VALUES ('{cp_id}', {ev_id[32:45]}, 'EV', 'active');").one()
@@ -4901,10 +4928,10 @@ class Enquiry:
             f"INSERT INTO notice_compiled_release (cp_id,oc_id, json_data, publish_date, release_date, "
             f"release_id, stage, status) VALUES ('{cp_id}', '{ev_id}', '{json.dumps(json_notice_compiled_release_ev)}',"
             f"{ev_id[32:45]},{ev_id[32:45]}, '{ev_id + '-' + ev_id[32:45]}','EV', 'active');").one()
-        record = f"http://dev.public.eprocurement.systems/tenders/{cp_id}"
-        ms_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
-        pn_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
-        ev_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{ev_id}"
+        record = f"{instance_tender_url}{cp_id}"
+        ms_release = f"{instance_tender_url}{cp_id}/{cp_id}"
+        pn_release = f"{instance_tender_url}{cp_id}/{pn_id}"
+        ev_release = f"{instance_tender_url}{cp_id}/{ev_id}"
         return cp_id, pn_id, pn_token, ev_id, record, ms_release, pn_release, ev_release, \
                enquiry_and_tender_period[0], enquiry_and_tender_period[1], enquiry_and_tender_period[2], \
                enquiry_and_tender_period[3]

--- a/tests/essences/enquiry.py
+++ b/tests/essences/enquiry.py
@@ -287,6 +287,7 @@ class Enquiry:
         auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)
         cluster = Cluster([self.cassandra_cluster], auth_provider=auth_provider)
         key_space_ocds = cluster.connect('ocds')
+        key_space_access = cluster.connect('access')
         key_space_clarification = cluster.connect('clarification')
         key_space_submission = cluster.connect('submission')
         key_space_auctions = cluster.connect('auctions')
@@ -3433,9 +3434,9 @@ class Enquiry:
 
         key_space_ocds.execute(f"INSERT INTO orchestrator_context (cp_id,context) VALUES ("
                                f"'{ev_id}','{json.dumps(json_orchestrator_context)}');").one()
-        key_space_ocds.execute(f"INSERT INTO access_tender (cpid, ocid, token_entity,created_date,json_data, owner) "
-                               f"VALUES ('{cp_id}', '{ev_id}', {pn_token}, {ev_id[32:45]}, "
-                               f"'{json.dumps(json_access_tender)}','{owner}');").one()
+        key_space_access.execute(f"INSERT INTO tenders (cpid, ocid, token_entity,created_date,json_data, owner) "
+                                 f"VALUES ('{cp_id}', '{ev_id}', '{pn_token}', {ev_id[32:45]}, "
+                                 f"'{json.dumps(json_access_tender)}','{owner}');").one()
         key_space_auctions.execute(
             f"INSERT INTO auctions (cpid, ocid, api_version, country, data, operation_id, row_version, status ) "
             f"VALUES ('{cp_id}', '{ev_id}', '1.0.0', '{self.country}', '{json.dumps(json_auction_auctions)}', "
@@ -3488,6 +3489,7 @@ class Enquiry:
         auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)
         cluster = Cluster([self.cassandra_cluster], auth_provider=auth_provider)
         key_space_ocds = cluster.connect('ocds')
+        key_space_access = cluster.connect('access')
         key_space_clarification = cluster.connect('clarification')
         key_space_submission = cluster.connect('submission')
         owner = "445f6851-c908-407d-9b45-14b92f3e964b"
@@ -4862,9 +4864,9 @@ class Enquiry:
 
         key_space_ocds.execute(f"INSERT INTO orchestrator_context (cp_id,context) VALUES ("
                                f"'{ev_id}','{json.dumps(json_orchestrator_context)}');").one()
-        key_space_ocds.execute(f"INSERT INTO access_tender (cpid, ocid, token_entity,created_date,json_data, owner) "
-                               f"VALUES ('{cp_id}', '{ev_id}', {pn_token}, {ev_id[32:45]}, "
-                               f"'{json.dumps(json_access_tender)}','{owner}');").one()
+        key_space_access.execute(f"INSERT INTO tenders (cpid, ocid, token_entity,created_date,json_data, owner) "
+                                 f"VALUES ('{cp_id}', '{ev_id}', '{pn_token}', {ev_id[32:45]}, "
+                                 f"'{json.dumps(json_access_tender)}','{owner}');").one()
         key_space_clarification.execute(
             f"INSERT INTO periods (cpid, ocid, end_date, owner, start_date) "
             f"VALUES ('{cp_id}', '{ev_id}', {get_timestamp_from_human_date_in_gmt_format(enquiry_and_tender_period[1])}, '{owner}', "
@@ -4915,6 +4917,7 @@ class Enquiry:
     #     auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)
     #     cluster = Cluster([self.cassandra_cluster], auth_provider=auth_provider)
     #     key_space_ocds = cluster.connect('ocds')
+    #     key_space_access = cluster.connect('access')
     #     key_space_clarification = cluster.connect('clarification')
     #     key_space_submission = cluster.connect('submission')
     #     key_space_auctions = cluster.connect('auctions')
@@ -8061,8 +8064,9 @@ class Enquiry:
     #
     #     key_space_ocds.execute(f"INSERT INTO orchestrator_context (cp_id,context) VALUES ("
     #                            f"'{ev_id}','{json.dumps(json_orchestrator_context)}');").one()
-    #     key_space_ocds.execute(f"INSERT INTO access_tender (cpid, ocid, token_entity,created_date,json_data, owner) "
-    #                            f"VALUES ('{cp_id}', '{ev_id}', {pn_token}, {ev_id[32:45]}, "
+    #     key_space_access.execute(f"INSERT INTO tenders (cpid, ocid, token_entity,created_date,json_data,
+    #     owner) "
+    #                            f"VALUES ('{cp_id}', '{ev_id}', '{pn_token}', {ev_id[32:45]}, "
     #                            f"'{json.dumps(json_access_tender)}','{owner}');").one()
     #     key_space_auctions.execute(
     #         f"INSERT INTO auctions (cpid, ocid, api_version, country, data, operation_id, row_version, status ) "

--- a/tests/essences/fs.py
+++ b/tests/essences/fs.py
@@ -648,11 +648,16 @@ class FS:
                         f"'{json.dumps(json_notice_budget_compiled_release_ei)}',"
                         f"1609943491271,1609943491271,'{cp_id + '-' + f'{period[2]}'}',"
                         f"'EI');").one()
+        instance_url = None
+        if self.instance == "dev":
+            instance_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_url = "http://public.eprocurement.systems/budgets/"
         allure.attach(owner, 'OWNER')
         allure.attach(cp_id, 'CPID')
         allure.attach(ei_token, 'X-TOKEN')
-        allure.attach(f"http://dev.public.eprocurement.systems/budgets/{cp_id}", 'URL')
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", ei_token, cp_id
+        allure.attach(f"{instance_url}{cp_id}", 'URL')
+        return f"{instance_url}{cp_id}", ei_token, cp_id
 
     @allure.step('Insert EI')
     def insert_ei_obligatory_data_model(self, cp_id, ei_token):
@@ -993,11 +998,16 @@ class FS:
                         f"'{json.dumps(json_notice_budget_compiled_release_ei)}',"
                         f"1609943491271,1609943491271,'{cp_id + '-' + f'{period[2]}'}',"
                         f"'EI');").one()
+        instance_url = None
+        if self.instance == "dev":
+            instance_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_url = "http://public.eprocurement.systems/budgets/"
         allure.attach(owner, 'OWNER')
         allure.attach(cp_id, 'CPID')
         allure.attach(ei_token, 'X-TOKEN')
-        allure.attach(f"http://dev.public.eprocurement.systems/budgets/{cp_id}", 'URL')
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}", ei_token, cp_id
+        allure.attach(f"{instance_url}{cp_id}", 'URL')
+        return f"{instance_url}{cp_id}/{cp_id}", ei_token, cp_id
 
     @allure.step('Insert EI')
     def insert_ei_full_data_model_without_item(self, cp_id, ei_token):
@@ -1299,11 +1309,16 @@ class FS:
                         f"'{json.dumps(json_notice_budget_compiled_release_ei)}',"
                         f"1609943491271,1609943491271,'{cp_id + '-' + f'{period[2]}'}',"
                         f"'EI');").one()
+        instance_url = None
+        if self.instance == "dev":
+            instance_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_url = "http://public.eprocurement.systems/budgets/"
         allure.attach(owner, 'OWNER')
         allure.attach(cp_id, 'CPID')
         allure.attach(ei_token, 'X-TOKEN')
-        allure.attach(f"http://dev.public.eprocurement.systems/budgets/{cp_id}", 'URL')
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", ei_token, cp_id
+        allure.attach(f"{instance_url}{cp_id}", 'URL')
+        return f"{instance_url}{cp_id}", ei_token, cp_id
 
     @allure.step('Insert FS: Treasury - obligatory, based on EI: without items - obligatory')
     def insert_fs_treasury_obligatory_ei_obligatory_without_items(self, cp_id, ei_token):
@@ -1815,7 +1830,12 @@ class FS:
             f"'{fs_id + '-' + str(period[2])}','FS');")
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{cp_id}',{period[2]});").one()
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", fs_id, fs_token
+        instance_url = None
+        if self.instance == "dev":
+            instance_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_url = "http://public.eprocurement.systems/budgets/"
+        return f"{instance_url}{cp_id}", fs_id, fs_token
 
     @allure.step('Insert FS: Treasury - full, based on EI: without items - obligatory')
     def insert_fs_treasury_full_ei_obligatory_without_items(self, cp_id, ei_token):
@@ -2384,7 +2404,12 @@ class FS:
             f"'{fs_id + '-' + str(period[2])}','FS');")
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{cp_id}',{period[2]});").one()
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", fs_id, fs_token
+        instance_url = None
+        if self.instance == "dev":
+            instance_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_url = "http://public.eprocurement.systems/budgets/"
+        return f"{instance_url}{cp_id}", fs_id, fs_token
 
     @allure.step('Insert FS: Treasury - obligatory, based on EI: without items - full')
     def insert_fs_treasury_obligatory_ei_full_without_items(self, cp_id, ei_token):
@@ -2947,7 +2972,12 @@ class FS:
             f"'{fs_id + '-' + str(period[2])}','FS');")
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{cp_id}',{period[2]});").one()
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", fs_id, fs_token
+        instance_url = None
+        if self.instance == "dev":
+            instance_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_url = "http://public.eprocurement.systems/budgets/"
+        return f"{instance_url}{cp_id}", fs_id, fs_token
 
     @allure.step('Insert FS: Treasury - full, based on EI: with items - obligatory')
     def insert_fs_treasury_full_ei_obligatory_with_items(self, cp_id, ei_token):
@@ -3608,7 +3638,12 @@ class FS:
             f"'{fs_id + '-' + str(period[2])}','FS');")
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{cp_id}',{period[2]});").one()
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", fs_id, fs_token
+        instance_url = None
+        if self.instance == "dev":
+            instance_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_url = "http://public.eprocurement.systems/budgets/"
+        return f"{instance_url}{cp_id}", fs_id, fs_token
 
     @allure.step('Insert FS: Own - obligatory, based on EI: without items - obligatory')
     def insert_fs_own_obligatory_ei_obligatory_without_items(self, cp_id, ei_token):
@@ -4236,7 +4271,12 @@ class FS:
             f"'{fs_id + '-' + str(period[2])}','FS');")
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{cp_id}',{period[2]});").one()
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", fs_id, fs_token
+        instance_url = None
+        if self.instance == "dev":
+            instance_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_url = "http://public.eprocurement.systems/budgets/"
+        return f"{instance_url}{cp_id}", fs_id, fs_token
 
     @allure.step('Insert FS: Own - full, based on EI: without items - obligatory')
     def insert_fs_own_full_ei_obligatory_without_items(self, cp_id, ei_token):
@@ -4979,7 +5019,12 @@ class FS:
             f"'{fs_id + '-' + str(period[2])}','FS');")
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{cp_id}',{period[2]});").one()
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", fs_id, fs_token
+        instance_url = None
+        if self.instance == "dev":
+            instance_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_url = "http://public.eprocurement.systems/budgets/"
+        return f"{instance_url}{cp_id}", fs_id, fs_token
 
     @allure.step('Insert FS: Own - obligatory, based on EI: with items - full')
     def insert_fs_own_obligatory_ei_full_with_items(self, cp_id, ei_token):
@@ -5805,7 +5850,12 @@ class FS:
             f"'{fs_id + '-' + str(period[2])}','FS');")
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{cp_id}',{period[2]});").one()
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", fs_id, fs_token
+        instance_url = None
+        if self.instance == "dev":
+            instance_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_url = "http://public.eprocurement.systems/budgets/"
+        return f"{instance_url}{cp_id}", fs_id, fs_token
 
     @allure.step('Insert FS: Own - full, based on EI: with items - full')
     def insert_fs_own_full_ei_full_with_items(self, cp_id, ei_token):
@@ -6734,7 +6784,12 @@ class FS:
             f"'{fs_id + '-' + str(period[2])}','FS');")
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{cp_id}',{period[2]});").one()
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", fs_id, fs_token
+        instance_url = None
+        if self.instance == "dev":
+            instance_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_url = "http://public.eprocurement.systems/budgets/"
+        return f"{instance_url}{cp_id}", fs_id, fs_token
 
     @allure.step('Receive message in feed-point')
     def get_message_from_kafka(self):

--- a/tests/essences/pn.py
+++ b/tests/essences/pn.py
@@ -263,6 +263,11 @@ class PN:
         fs_id = prepared_fs_oc_id(cp_id)
         fs_token = uuid4()
         period = get_period()
+        instance_budget_url = None
+        if self.instance == "dev":
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid4()}",
@@ -496,7 +501,7 @@ class PN:
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": f"{fs_id}",
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{fs_id}"
             }]
         }
 
@@ -572,7 +577,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -655,7 +660,7 @@ class PN:
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": f"{fs_id}",
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{fs_id}"
             }]
         }
 
@@ -731,7 +736,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": f"{cp_id}",
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -764,7 +769,7 @@ class PN:
             f"'{fs_id + '-' + str(period[2])}','FS');")
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{cp_id}',{period[2]});").one()
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", fs_id, fs_token
+        return f"{instance_budget_url}{cp_id}", fs_id, fs_token
 
     @allure.step('Insert FS: Treasury - full, based on EI: without items - obligatory')
     def insert_fs_treasury_full_ei_obligatory_without_items(self, cp_id, ei_token):
@@ -775,6 +780,11 @@ class PN:
         fs_id = prepared_fs_oc_id(cp_id)
         fs_token = uuid4()
         period = get_period()
+        instance_budget_url = None
+        if self.instance == "dev":
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid4()}",
@@ -1023,7 +1033,7 @@ class PN:
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": f"{fs_id}",
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{fs_id}"
             }]
         }
 
@@ -1120,7 +1130,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -1203,7 +1213,7 @@ class PN:
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": f"{fs_id}",
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{fs_id}"
             }]
         }
 
@@ -1300,7 +1310,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": f"{cp_id}",
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -1333,7 +1343,7 @@ class PN:
             f"'{fs_id + '-' + str(period[2])}','FS');")
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{cp_id}',{period[2]});").one()
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", fs_id, fs_token
+        return f"{instance_budget_url}{cp_id}", fs_id, fs_token
 
     @allure.step('Insert FS: Treasury - obligatory, based on EI: without items - full')
     def insert_fs_treasury_obligatory_ei_full_without_items(self, cp_id, ei_token):
@@ -1344,6 +1354,11 @@ class PN:
         fs_id = prepared_fs_oc_id(cp_id)
         fs_token = uuid4()
         period = get_period()
+        instance_budget_url = None
+        if self.instance == "dev":
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid4()}",
@@ -1611,7 +1626,7 @@ class PN:
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": f"{fs_id}",
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{fs_id}"
             }]
         }
 
@@ -1687,7 +1702,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -1787,7 +1802,7 @@ class PN:
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": f"{fs_id}",
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{fs_id}"
             }]
         }
 
@@ -1863,7 +1878,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": f"{cp_id}",
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -1896,7 +1911,7 @@ class PN:
             f"'{fs_id + '-' + str(period[2])}','FS');")
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{cp_id}',{period[2]});").one()
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", fs_id, fs_token
+        return f"{instance_budget_url}{cp_id}", fs_id, fs_token
 
     @allure.step('Insert FS: Treasury - full, based on EI: with items - obligatory')
     def insert_fs_treasury_full_ei_obligatory_with_items(self, cp_id, ei_token):
@@ -1907,6 +1922,11 @@ class PN:
         fs_id = prepared_fs_oc_id(cp_id)
         fs_token = uuid4()
         period = get_period()
+        instance_budget_url = None
+        if self.instance == "dev":
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid4()}",
@@ -2216,7 +2236,7 @@ class PN:
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": f"{fs_id}",
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{fs_id}"
             }]
         }
 
@@ -2313,7 +2333,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -2427,7 +2447,7 @@ class PN:
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": f"{fs_id}",
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{fs_id}"
             }]
         }
 
@@ -2524,7 +2544,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": f"{cp_id}",
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -2557,7 +2577,7 @@ class PN:
             f"'{fs_id + '-' + str(period[2])}','FS');")
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{cp_id}',{period[2]});").one()
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", fs_id, fs_token
+        return f"{instance_budget_url}{cp_id}", fs_id, fs_token
 
     @allure.step('Insert FS: Own - obligatory, based on EI: without items - obligatory')
     def insert_fs_own_obligatory_ei_obligatory_without_items(self, cp_id, ei_token):
@@ -2568,6 +2588,11 @@ class PN:
         fs_id = prepared_fs_oc_id(cp_id)
         fs_token = uuid4()
         period = get_period()
+        instance_budget_url = None
+        if self.instance == "dev":
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid4()}",
@@ -2840,7 +2865,7 @@ class PN:
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": f"{fs_id}",
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{fs_id}"
             }]
         }
 
@@ -2954,7 +2979,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -3037,7 +3062,7 @@ class PN:
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": f"{fs_id}",
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{fs_id}"
             }]
         }
 
@@ -3152,7 +3177,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": f"{cp_id}",
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -3185,7 +3210,7 @@ class PN:
             f"'{fs_id + '-' + str(period[2])}','FS');")
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{cp_id}',{period[2]});").one()
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", fs_id, fs_token
+        return f"{instance_budget_url}{cp_id}", fs_id, fs_token
 
     @allure.step('Insert FS: Own - full, based on EI: without items - obligatory')
     def insert_fs_own_full_ei_obligatory_without_items(self, cp_id, ei_token):
@@ -3196,6 +3221,11 @@ class PN:
         fs_id = prepared_fs_oc_id(cp_id)
         fs_token = uuid4()
         period = get_period()
+        instance_budget_url = None
+        if self.instance == "dev":
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid4()}",
@@ -3498,7 +3528,7 @@ class PN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{cp_id}/{fs_id}"
                 }]
         }
 
@@ -3651,7 +3681,7 @@ class PN:
                         "parent"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}"
+                    "uri": f"{instance_budget_url}{cp_id}/{cp_id}"
                 }]
         }
 
@@ -3739,7 +3769,7 @@ class PN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{cp_id}/{fs_id}"
                 }]
         }
 
@@ -3893,7 +3923,7 @@ class PN:
                         "parent"],
                     "scheme": "ocid",
                     "identifier": f"{cp_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}"
+                    "uri": f"{instance_budget_url}{cp_id}/{cp_id}"
                 }]
         }
 
@@ -3928,7 +3958,7 @@ class PN:
             f"'{fs_id + '-' + str(period[2])}','FS');")
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{cp_id}',{period[2]});").one()
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", fs_id, fs_token
+        return f"{instance_budget_url}{cp_id}", fs_id, fs_token
 
     @allure.step('Insert FS: Own - obligatory, based on EI: with items - full')
     def insert_fs_own_obligatory_ei_full_with_items(self, cp_id, ei_token):
@@ -3939,6 +3969,11 @@ class PN:
         fs_id = prepared_fs_oc_id(cp_id)
         fs_token = uuid4()
         period = get_period()
+        instance_budget_url = None
+        if self.instance == "dev":
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid4()}",
@@ -4340,7 +4375,7 @@ class PN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{cp_id}/{fs_id}"
                 }]
         }
 
@@ -4455,7 +4490,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -4606,7 +4641,7 @@ class PN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{cp_id}/{fs_id}"
                 }]
         }
 
@@ -4721,7 +4756,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": f"{cp_id}",
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}"
+                "uri": f"{instance_budget_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -4754,7 +4789,7 @@ class PN:
             f"'{fs_id + '-' + str(period[2])}','FS');")
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{cp_id}',{period[2]});").one()
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", fs_id, fs_token
+        return f"{instance_budget_url}{cp_id}", fs_id, fs_token
 
     @allure.step('Insert FS: Own - full, based on EI: with items - full')
     def insert_fs_own_full_ei_full_with_items(self, cp_id, ei_token):
@@ -4765,6 +4800,11 @@ class PN:
         fs_id = prepared_fs_oc_id(cp_id)
         fs_token = uuid4()
         period = get_period()
+        instance_budget_url = None
+        if self.instance == "dev":
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+        if self.instance == "sandbox":
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid4()}",
@@ -5193,7 +5233,7 @@ class PN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{cp_id}/{fs_id}"
                 }]
         }
 
@@ -5344,7 +5384,7 @@ class PN:
                         "parent"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}"
+                    "uri": f"{instance_budget_url}{cp_id}/{cp_id}"
                 }]
         }
 
@@ -5495,7 +5535,7 @@ class PN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{cp_id}/{fs_id}"
                 }]
         }
 
@@ -5648,7 +5688,7 @@ class PN:
                         "parent"],
                     "scheme": "ocid",
                     "identifier": f"{cp_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{cp_id}/{cp_id}"
+                    "uri": f"{instance_budget_url}{cp_id}/{cp_id}"
                 }]
         }
 
@@ -5683,7 +5723,7 @@ class PN:
             f"'{fs_id + '-' + str(period[2])}','FS');")
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{cp_id}',{period[2]});").one()
-        return f"http://dev.public.eprocurement.systems/budgets/{cp_id}", fs_id, fs_token
+        return f"{instance_budget_url}{cp_id}", fs_id, fs_token
 
     @allure.step('Receive message in feed-point')
     def get_message_from_kafka(self):
@@ -5759,6 +5799,7 @@ class PN:
         auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)
         cluster = Cluster([self.cassandra_cluster], auth_provider=auth_provider)
         session = cluster.connect('ocds')
+        session_access = cluster.connect('access')
         owner = "445f6851-c908-407d-9b45-14b92f3e964b"
         ei_id = prepared_cp_id()
         ei_token = uuid4()
@@ -5815,6 +5856,17 @@ class PN:
         procurement_method_details_from_mdm = data_pn["data"]["tender"]["procurementMethodDetails"]
         eligibility_criteria_from_mdm = data_pn["data"]["tender"]["eligibilityCriteria"]
 
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if self.instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if self.instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid4()}",
@@ -6627,7 +6679,7 @@ class PN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
                 },
                 {
                     "id": "31bd7be0-c23c-11eb-ab87-09e4e5e94b2a",
@@ -6635,7 +6687,7 @@ class PN:
                         "x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -6788,7 +6840,7 @@ class PN:
                         "parent"],
                     "scheme": "ocid",
                     "identifier": ei_id,
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
                 },
                 {
                     "id": "31bda2f0-c23c-11eb-ab87-09e4e5e94b2a",
@@ -6796,7 +6848,7 @@ class PN:
                         "x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -6949,14 +7001,14 @@ class PN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
                 },
                 {
                     "id": "ce7f5070-c057-11eb-ab87-09e4e5e94b2a",
                     "relationship": ["x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -7110,14 +7162,14 @@ class PN:
                         "parent"],
                     "scheme": "ocid",
                     "identifier": f"{ei_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
                 },
                 {
                     "id": "ce7f7780-c057-11eb-ab87-09e4e5e94b2a",
                     "relationship": ["x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -7420,19 +7472,19 @@ class PN:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/o{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/o{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/o{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/o{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_tender_url}{ei_id}/{fs_id}"
             }]
         }
 
@@ -7636,7 +7688,7 @@ class PN:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_one_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [first_lot_id]
@@ -7646,7 +7698,7 @@ class PN:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_two_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [second_lot_id]
@@ -7675,7 +7727,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -7972,19 +8024,19 @@ class PN:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             }]
 
         }
@@ -8189,7 +8241,7 @@ class PN:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_one_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [first_lot_id]
@@ -8199,7 +8251,7 @@ class PN:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_two_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [second_lot_id]
@@ -8228,7 +8280,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -8261,9 +8313,9 @@ class PN:
             f"'{fs_id + '-' + str(pn_id[32:45])}','FS');").one()
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{ei_id}', {pn_id[32:45]});").one()
-        session.execute(
-            f"INSERT INTO access_tender (cpid,ocid,token_entity,created_date,json_data, owner) "
-            f"VALUES ('{cp_id}', '{pn_id}', {pn_token}, {pn_id[32:45]}, "
+        session_access.execute(
+            f"INSERT INTO tenders (cpid,ocid,token_entity,created_date,json_data, owner) "
+            f"VALUES ('{cp_id}', '{pn_id}', '{pn_token}', {pn_id[32:45]}, "
             f"'{json.dumps(json_access_tender)}','{owner}');").one()
         session.execute(
             f"INSERT INTO notice_release (cp_id,oc_id, release_id, json_data, release_date, stage) "
@@ -8284,9 +8336,9 @@ class PN:
 
         session.execute(f"INSERT INTO notice_offset (cp_id,release_date, stage, status) "
                         f"VALUES ('{cp_id}', {pn_id[32:45]}, 'PN', 'planning');").one()
-        pn_record = f"http://dev.public.eprocurement.systems/tenders/{cp_id}"
-        ms_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
-        pn_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+        pn_record = f"{instance_tender_url}{cp_id}"
+        ms_release = f"{instance_tender_url}{cp_id}/{cp_id}"
+        pn_release = f"{instance_tender_url}{cp_id}/{pn_id}"
         return ei_id, ei_token, fs_id, fs_token, cp_id, pn_id, pn_token, pn_record, ms_release, pn_release
 
     @allure.step('Insert PN: based on FS: treasury - obligatory, based on EI: without items - obligatory')
@@ -8294,6 +8346,7 @@ class PN:
         auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)
         cluster = Cluster([self.cassandra_cluster], auth_provider=auth_provider)
         session = cluster.connect('ocds')
+        session_access = cluster.connect('access')
         owner = "445f6851-c908-407d-9b45-14b92f3e964b"
         ei_id = prepared_cp_id()
         ei_token = uuid4()
@@ -8317,6 +8370,17 @@ class PN:
         submission_method_rationale = data_pn["data"]["tender"]["submissionMethodRationale"]
         procurement_method_details_from_mdm = data_pn["data"]["tender"]["procurementMethodDetails"]
         eligibility_criteria_from_mdm = data_pn["data"]["tender"]["eligibilityCriteria"]
+
+        instance_tender_url = None
+        instance_budget_url = None
+
+        if self.instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+
+        if self.instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
 
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
@@ -8708,7 +8772,7 @@ class PN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
                 },
                 {
                     "id": "31bd7be0-c23c-11eb-ab87-09e4e5e94b2a",
@@ -8716,7 +8780,7 @@ class PN:
                         "x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -8797,7 +8861,7 @@ class PN:
                         "parent"],
                     "scheme": "ocid",
                     "identifier": ei_id,
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
                 },
                 {
                     "id": "31bda2f0-c23c-11eb-ab87-09e4e5e94b2a",
@@ -8805,7 +8869,7 @@ class PN:
                         "x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -8894,14 +8958,14 @@ class PN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
                 },
                 {
                     "id": "ce7f5070-c057-11eb-ab87-09e4e5e94b2a",
                     "relationship": ["x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -8983,14 +9047,14 @@ class PN:
                         "parent"],
                     "scheme": "ocid",
                     "identifier": f"{ei_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
                 },
                 {
                     "id": "ce7f7780-c057-11eb-ab87-09e4e5e94b2a",
                     "relationship": ["x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -9193,19 +9257,19 @@ class PN:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/o{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/o{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/o{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/o{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             }]
         }
 
@@ -9252,7 +9316,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -9453,19 +9517,19 @@ class PN:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             }]
 
         }
@@ -9513,7 +9577,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -9546,9 +9610,9 @@ class PN:
             f"'{fs_id + '-' + str(pn_id[32:45])}','FS');").one()
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{ei_id}', {pn_id[32:45]});").one()
-        session.execute(
-            f"INSERT INTO access_tender (cpid,ocid,token_entity,created_date,json_data, owner) "
-            f"VALUES ('{cp_id}', '{pn_id}', {pn_token}, {pn_id[32:45]}, "
+        session_access.execute(
+            f"INSERT INTO tenders (cpid,ocid,token_entity,created_date,json_data, owner) "
+            f"VALUES ('{cp_id}', '{pn_id}', '{pn_token}', {pn_id[32:45]}, "
             f"'{json.dumps(json_access_tender)}','{owner}');").one()
         session.execute(
             f"INSERT INTO notice_release (cp_id,oc_id, release_id, json_data, release_date, stage) "
@@ -9569,10 +9633,9 @@ class PN:
 
         session.execute(f"INSERT INTO notice_offset (cp_id,release_date, stage, status) "
                         f"VALUES ('{cp_id}', {pn_id[32:45]}, 'PN', 'planning');").one()
-
-        pn_record = f"http://dev.public.eprocurement.systems/tenders/{cp_id}"
-        ms_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
-        pn_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+        pn_record = f"{instance_tender_url}{cp_id}"
+        ms_release = f"{instance_tender_url}{cp_id}/{cp_id}"
+        pn_release = f"{instance_tender_url}{cp_id}/{pn_id}"
         return ei_id, ei_token, fs_id, fs_token, cp_id, pn_id, pn_token, pn_record, ms_release, pn_release
 
     # ---------------------------------------------------------------------------------------
@@ -9581,6 +9644,7 @@ class PN:
         auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)
         cluster = Cluster([self.cassandra_cluster], auth_provider=auth_provider)
         session = cluster.connect('ocds')
+        session_access = cluster.connect('access')
         owner = "445f6851-c908-407d-9b45-14b92f3e964b"
         ei_id = prepared_cp_id()
         ei_token = uuid4()
@@ -9637,6 +9701,17 @@ class PN:
         procurement_method_details_from_mdm = data_pn["data"]["tender"]["procurementMethodDetails"]
         eligibility_criteria_from_mdm = data_pn["data"]["tender"]["eligibilityCriteria"]
 
+        instance_tender_url = None
+        instance_budget_url = None
+        instance_storage_url = None
+        if self.instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+            instance_storage_url = "https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+        if self.instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
+            instance_storage_url = "http://storage.eprocurement.systems/get/"
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
             "requestId": f"{uuid4()}",
@@ -10449,7 +10524,7 @@ class PN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
                 },
                 {
                     "id": "31bd7be0-c23c-11eb-ab87-09e4e5e94b2a",
@@ -10457,7 +10532,7 @@ class PN:
                         "x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -10610,7 +10685,7 @@ class PN:
                         "parent"],
                     "scheme": "ocid",
                     "identifier": ei_id,
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
                 },
                 {
                     "id": "31bda2f0-c23c-11eb-ab87-09e4e5e94b2a",
@@ -10618,7 +10693,7 @@ class PN:
                         "x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -10771,14 +10846,14 @@ class PN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
                 },
                 {
                     "id": "ce7f5070-c057-11eb-ab87-09e4e5e94b2a",
                     "relationship": ["x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -10932,14 +11007,14 @@ class PN:
                         "parent"],
                     "scheme": "ocid",
                     "identifier": f"{ei_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
                 },
                 {
                     "id": "ce7f7780-c057-11eb-ab87-09e4e5e94b2a",
                     "relationship": ["x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -11242,19 +11317,19 @@ class PN:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/o{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/o{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/o{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/o{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             }]
         }
 
@@ -11458,7 +11533,7 @@ class PN:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_one_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [first_lot_id]
@@ -11468,7 +11543,7 @@ class PN:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_two_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [second_lot_id]
@@ -11497,7 +11572,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -11794,19 +11869,19 @@ class PN:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
             }]
 
         }
@@ -12011,7 +12086,7 @@ class PN:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_one_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [first_lot_id]
@@ -12021,7 +12096,7 @@ class PN:
                         "documentType": "contractArrangements",
                         "title": "title of document",
                         "description": "descrition of document",
-                        "url": f"https://dev.bpe.eprocurement.systems/api/v1/storage/get/"
+                        "url": f"{instance_storage_url}"
                                f"{self.document_two_was_uploaded}",
                         "datePublished": f"{get_human_date_in_utc_format(int(pn_id[32:45]))[0]}",
                         "relatedLots": [second_lot_id]
@@ -12050,7 +12125,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -12083,9 +12158,9 @@ class PN:
             f"'{fs_id + '-' + str(pn_id[32:45])}','FS');").one()
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{ei_id}', {pn_id[32:45]});").one()
-        session.execute(
-            f"INSERT INTO access_tender (cpid,ocid,token_entity,created_date,json_data, owner) "
-            f"VALUES ('{cp_id}', '{pn_id}', {pn_token}, {pn_id[32:45]}, "
+        session_access.execute(
+            f"INSERT INTO tenders (cpid,ocid,token_entity,created_date,json_data, owner) "
+            f"VALUES ('{cp_id}', '{pn_id}', '{pn_token}', {pn_id[32:45]}, "
             f"'{json.dumps(json_access_tender)}','{owner}');").one()
         session.execute(
             f"INSERT INTO notice_release (cp_id,oc_id, release_id, json_data, release_date, stage) "
@@ -12106,9 +12181,9 @@ class PN:
 
         session.execute(f"INSERT INTO notice_offset (cp_id,release_date, stage, status) "
                         f"VALUES ('{cp_id}', {pn_id[32:45]}, 'PN', 'planning');").one()
-        pn_record = f"http://dev.public.eprocurement.systems/tenders/{cp_id}"
-        ms_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
-        pn_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+        pn_record = f"{instance_tender_url}{cp_id}"
+        ms_release = f"{instance_tender_url}{cp_id}/{cp_id}"
+        pn_release = f"{instance_tender_url}{cp_id}/{pn_id}"
         return ei_id, ei_token, fs_id, fs_token, cp_id, pn_id, pn_token, pn_record, ms_release, pn_release
 
     # ==================================
@@ -12118,6 +12193,7 @@ class PN:
         auth_provider = PlainTextAuthProvider(username=self.cassandra_username, password=self.cassandra_password)
         cluster = Cluster([self.cassandra_cluster], auth_provider=auth_provider)
         session = cluster.connect('ocds')
+        session_access = cluster.connect('access')
         owner = "445f6851-c908-407d-9b45-14b92f3e964b"
         ei_id = prepared_cp_id()
         ei_token = uuid4()
@@ -12141,6 +12217,17 @@ class PN:
         submission_method_rationale = data_pn["data"]["tender"]["submissionMethodRationale"]
         procurement_method_details_from_mdm = data_pn["data"]["tender"]["procurementMethodDetails"]
         eligibility_criteria_from_mdm = data_pn["data"]["tender"]["eligibilityCriteria"]
+
+        instance_tender_url = None
+        instance_budget_url = None
+
+        if self.instance == "dev":
+            instance_tender_url = "http://dev.public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://dev.public.eprocurement.systems/budgets/"
+
+        if self.instance == "sandbox":
+            instance_tender_url = "http://public.eprocurement.systems/tenders/"
+            instance_budget_url = "http://public.eprocurement.systems/budgets/"
 
         json_orchestrator_context = {
             "operationId": f"{uuid4()}",
@@ -12532,7 +12619,7 @@ class PN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
                 },
                 {
                     "id": "31bd7be0-c23c-11eb-ab87-09e4e5e94b2a",
@@ -12540,7 +12627,7 @@ class PN:
                         "x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -12621,7 +12708,7 @@ class PN:
                         "parent"],
                     "scheme": "ocid",
                     "identifier": ei_id,
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
                 },
                 {
                     "id": "31bda2f0-c23c-11eb-ab87-09e4e5e94b2a",
@@ -12629,7 +12716,7 @@ class PN:
                         "x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -12718,14 +12805,14 @@ class PN:
                         "x_fundingSource"],
                     "scheme": "ocid",
                     "identifier": f"{fs_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{fs_id}"
                 },
                 {
                     "id": "ce7f5070-c057-11eb-ab87-09e4e5e94b2a",
                     "relationship": ["x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -12807,14 +12894,14 @@ class PN:
                         "parent"],
                     "scheme": "ocid",
                     "identifier": f"{ei_id}",
-                    "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                    "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
                 },
                 {
                     "id": "ce7f7780-c057-11eb-ab87-09e4e5e94b2a",
                     "relationship": ["x_execution"],
                     "scheme": "ocid",
                     "identifier": cp_id,
-                    "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                    "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
                 }
             ]
         }
@@ -13017,19 +13104,19 @@ class PN:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/o{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/o{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_tender_url}{ei_id}/{fs_id}"
             }]
         }
 
@@ -13076,7 +13163,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -13277,19 +13364,19 @@ class PN:
                 "relationship": ["planning"],
                 "scheme": "ocid",
                 "identifier": pn_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{pn_id}"
             }, {
                 "id": "36b553f1-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_expenditureItem"],
                 "scheme": "ocid",
                 "identifier": ei_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{ei_id}"
+                "uri": f"{instance_budget_url}{ei_id}/{ei_id}"
             }, {
                 "id": "36b553f2-c072-11eb-ab87-09e4e5e94b2a",
                 "relationship": ["x_fundingSource"],
                 "scheme": "ocid",
                 "identifier": fs_id,
-                "uri": f"http://dev.public.eprocurement.systems/budgets/{ei_id}/{fs_id}"
+                "uri": f"{instance_tender_url}{ei_id}/{fs_id}"
             }]
 
         }
@@ -13337,7 +13424,7 @@ class PN:
                 "relationship": ["parent"],
                 "scheme": "ocid",
                 "identifier": cp_id,
-                "uri": f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
+                "uri": f"{instance_tender_url}{cp_id}/{cp_id}"
             }]
         }
 
@@ -13370,9 +13457,9 @@ class PN:
             f"'{fs_id + '-' + str(pn_id[32:45])}','FS');").one()
         session.execute(f"INSERT INTO notice_budget_offset (cp_id,release_date) "
                         f"VALUES ('{ei_id}', {pn_id[32:45]});").one()
-        session.execute(
-            f"INSERT INTO access_tender (cpid,ocid,token_entity,created_date,json_data, owner) "
-            f"VALUES ('{cp_id}', '{pn_id}', {pn_token}, {pn_id[32:45]}, "
+        session_access.execute(
+            f"INSERT INTO tenders (cpid,ocid,token_entity,created_date,json_data, owner) "
+            f"VALUES ('{cp_id}', '{pn_id}', '{pn_token}', {pn_id[32:45]}, "
             f"'{json.dumps(json_access_tender)}','{owner}');").one()
         session.execute(
             f"INSERT INTO notice_release (cp_id,oc_id, release_id, json_data, release_date, stage) "
@@ -13393,8 +13480,7 @@ class PN:
 
         session.execute(f"INSERT INTO notice_offset (cp_id,release_date, stage, status) "
                         f"VALUES ('{cp_id}', {pn_id[32:45]}, 'PN', 'planning');").one()
-
-        pn_record = f"http://dev.public.eprocurement.systems/tenders/{cp_id}"
-        ms_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{cp_id}"
-        pn_release = f"http://dev.public.eprocurement.systems/tenders/{cp_id}/{pn_id}"
+        pn_record = f"{instance_tender_url}{cp_id}"
+        ms_release = f"{instance_tender_url}{cp_id}/{cp_id}"
+        pn_release = f"{instance_tender_url}{cp_id}/{pn_id}"
         return ei_id, ei_token, fs_id, fs_token, cp_id, pn_id, pn_token, pn_record, ms_release, pn_release


### PR DESCRIPTION
13/07/2021 19:00:
Summary: remove hardcode from everywhere and use url as variable.
Autotests done for 'dev' and 'sandbox' environment,  open procedure [create/update EI, create/update FS, create/update/cancel PN, create/update CnOnPn, create amendment (cancel tender/lot),  confirmation amendment (cancel tender/lot), cancellation amendment (cancel tender/lot), enquiry period end (create enquiry, suspended)]