### PR TITLE
14/07/2021 11:15:

### DIFF
--- a/tests/bpe_create_ei/test_bpe_create_ei.py
+++ b/tests/bpe_create_ei/test_bpe_create_ei.py
@@ -1450,7 +1450,7 @@ class TestCheckTheIdentificationOfTenderEqualsTheOCIDofTheEI(object):
                 cassandra_username=cassandra_username, cassandra_password=cassandra_password)
         ei.create_ei()
         ei.get_message_from_kafka()
-        actual_result = str(ei.check_on_that_message_is_successfully_create_ei(instance))
+        actual_result = str(ei.check_on_that_message_is_successfully_create_ei())
         expected_result = str(True)
         assert compare_actual_result_and_expected_result(expected_result=expected_result,
                                                          actual_result=actual_result)
@@ -2434,10 +2434,6 @@ class TestCheckOnPossibilityToCreateEiWithFullDataModel(object):
         ei_release_timestamp = int(ei_release["releases"][0]["id"][29:42])
         convert_timestamp_to_date = get_human_date_in_utc_format(ei_release_timestamp)
         keys_list = list()
-        if instance == 'dev':
-            instance_url = "http://dev.public.eprocurement.systems/budgets/"
-        if instance == 'sandbox':
-            instance_url = "http://public.eprocurement.systems/budgets/"
 
         for i in ei_release.keys():
             if i == "uri":


### PR DESCRIPTION
Summary: hotfix create EI.
Autotests done for 'dev' and 'sandbox' environment,  open procedure [create EI]

-> tests/bpe_create_ei/test_bpe_create_ei.py
1) refactor: correct call 'check_on_that_message_is_successfully_create_ei' method.